### PR TITLE
래더 게임을 위한 대기큐 만들기

### DIFF
--- a/nestjs/src/socket/game/game.gateway.ts
+++ b/nestjs/src/socket/game/game.gateway.ts
@@ -23,6 +23,8 @@ export class GameGateway
   constructor(@Inject(NormalJwt) private readonly jwtService: JwtService) {}
   @WebSocketServer() server: Server;
 
+  private ladderQueue: Socket[] = [];
+
   afterInit(server: Server) {
     console.log(`game socket: ${server} init`);
   }
@@ -33,10 +35,15 @@ export class GameGateway
 
   handleDisconnect(client: Socket) {
     console.log(`game socket: ${client.id} disconnected`);
+    this.ladderQueue.pop();
   }
 
   @SubscribeMessage('joinQueue')
-  handleMessage(client: any, payload: any): void {
+  handleMessage(client: Socket): void {
     console.log('join queue');
+    this.ladderQueue.push(client);
+    this.ladderQueue.forEach(socket => {
+      console.log(socket.id);
+    });
   }
 }

--- a/nestjs/src/socket/game/game.gateway.ts
+++ b/nestjs/src/socket/game/game.gateway.ts
@@ -35,15 +35,30 @@ export class GameGateway
 
   handleDisconnect(client: Socket) {
     console.log(`game socket: ${client.id} disconnected`);
-    this.ladderQueue.pop();
+    this.ladderQueue = this.ladderQueue.filter(
+      element => element.id !== client.id,
+    );
+    console.log(`matching queue length : ${this.ladderQueue.length}`);
   }
 
   @SubscribeMessage('joinQueue')
   handleMessage(client: Socket): void {
     console.log('join queue');
     this.ladderQueue.push(client);
-    this.ladderQueue.forEach(socket => {
-      console.log(socket.id);
-    });
+    console.log(`matching queue pushed : ${this.ladderQueue.length}`);
+    if (this.ladderQueue.length === 2) {
+      const frontSocket = this.ladderQueue[0];
+      const backSocket = this.ladderQueue[1];
+      if (frontSocket.id === backSocket.id) {
+        console.log(`same socket! pop() queue`);
+        this.ladderQueue.pop();
+        console.log(`queue length : ${this.ladderQueue.length}`);
+        return;
+      }
+      backSocket.leave(backSocket.id);
+      backSocket.join(frontSocket.id);
+      this.ladderQueue = [];
+      this.server.to(frontSocket.id).emit('joinGame');
+    }
   }
 }

--- a/nestjs/src/socket/game/game.gateway.ts
+++ b/nestjs/src/socket/game/game.gateway.ts
@@ -46,7 +46,7 @@ export class GameGateway
     console.log('join queue');
     this.ladderQueue.push(client);
     console.log(`matching queue pushed : ${this.ladderQueue.length}`);
-    if (this.ladderQueue.length === 2) {
+    if (this.ladderQueue.length >= 2) {
       const frontSocket = this.ladderQueue[0];
       const backSocket = this.ladderQueue[1];
       if (frontSocket.id === backSocket.id) {


### PR DESCRIPTION
## 관련 이슈
- #49 

## 요약
- 래더게임의 대기 큐 생성 및 매칭 시스템 구현
<br><br>

## 작업내용
- joinQueue 이벤트 발생시 대기 큐에 소켓을 넣어서 매칭을 대기함
- room 번호는 소켓의 default room 번호인 소켓 아이디를 사용함
- 소켓 연결 끊어 졌을때 큐에서 제거함
<br><br>

## 참고사항

<br><br>
