### PR TITLE
Feat protected 채팅방에 참여할때 비밀번호 검증 기능 추가

### DIFF
--- a/nestjs/src/chat/chat.controller.ts
+++ b/nestjs/src/chat/chat.controller.ts
@@ -13,10 +13,10 @@ import {
 import { ChatService } from './chat.service';
 import { AuthGuard } from '@nestjs/passport';
 import { CreateChatDto } from './dto/chatCreate.dto';
-import { ChatParticipantCreateDto } from './dto/chatParticipantCreate.dto';
 import { Chat } from './entities/chat.entity';
 import { ChatParticipant } from './entities/chatParticipant.entity';
 import { ChatParticipantAuthority } from './enum/chatParticipant.authority.enum';
+import { ChatJoinDto } from './dto/chatJoin.dto';
 
 @Controller('chat')
 @UseGuards(AuthGuard('jwt'))
@@ -56,11 +56,8 @@ export class ChatController {
   }
 
   @Post('participant')
-  joinChat(
-    @Body() chatParticipantCreateDto: ChatParticipantCreateDto,
-    @Req() req,
-  ) {
-    return this.chatService.joinChat(chatParticipantCreateDto, req.user.id);
+  joinChat(@Body() chatJoinDto: ChatJoinDto, @Req() req) {
+    return this.chatService.joinChat(chatJoinDto, req.user.id);
   }
 
   @Patch('participant/authority/:user_id/:chat_room_id')

--- a/nestjs/src/chat/chat.controller.ts
+++ b/nestjs/src/chat/chat.controller.ts
@@ -68,24 +68,32 @@ export class ChatController {
     @Param('user_id', ParseIntPipe) user_id: number,
     @Param('chat_room_id', ParseIntPipe) chat_room_id: number,
     @Body() authority: ChatParticipantAuthority,
+    @Req() req,
   ) {
-    return this.chatService.updateAuthority(user_id, chat_room_id, authority);
+    return this.chatService.updateAuthority(
+      user_id,
+      chat_room_id,
+      authority,
+      req.user.id,
+    );
   }
 
   @Patch('participant/ban/:user_id/:chat_room_id')
   switchBan(
     @Param('user_id', ParseIntPipe) user_id: number,
     @Param('chat_room_id', ParseIntPipe) chat_room_id: number,
+    @Req() req,
   ) {
-    return this.chatService.updateBan(user_id, chat_room_id);
+    return this.chatService.updateBan(user_id, chat_room_id, req.user.id);
   }
 
   @Patch('participant/notban/:user_id/:chat_room_id')
   switchNotBan(
     @Param('user_id', ParseIntPipe) user_id: number,
     @Param('chat_room_id', ParseIntPipe) chat_room_id: number,
+    @Req() req,
   ) {
-    return this.chatService.updateNotBan(user_id, chat_room_id);
+    return this.chatService.updateNotBan(user_id, chat_room_id, req.user.id);
   }
 
   @Delete('/:user_id/:chat_room_id')

--- a/nestjs/src/chat/chat.controller.ts
+++ b/nestjs/src/chat/chat.controller.ts
@@ -16,7 +16,7 @@ import { CreateChatDto } from './dto/chatCreate.dto';
 import { ChatParticipantCreateDto } from './dto/chatParticipantCreate.dto';
 import { Chat } from './entities/chat.entity';
 import { ChatParticipant } from './entities/chatParticipant.entity';
-import { ChatParticipantStatus } from './enum/chatParticipant.status.enum';
+import { ChatParticipantAuthority } from './enum/chatParticipant.authority.enum';
 
 @Controller('chat')
 @UseGuards(AuthGuard('jwt'))
@@ -60,13 +60,13 @@ export class ChatController {
     return this.chatService.joinChat(chatParticipantCreateDto, req.user.id);
   }
 
-  @Patch('participant/status/:user_id/:chat_room_id')
-  switchStatus(
+  @Patch('participant/authority/:user_id/:chat_room_id')
+  switchAuthority(
     @Param('user_id', ParseIntPipe) user_id: number,
     @Param('chat_room_id', ParseIntPipe) chat_room_id: number,
-    @Body() status: ChatParticipantStatus,
+    @Body() authority: ChatParticipantAuthority,
   ) {
-    return this.chatService.updateStatus(user_id, chat_room_id, status);
+    return this.chatService.updateAuthority(user_id, chat_room_id, authority);
   }
 
   @Patch('participant/ban/:user_id/:chat_room_id')

--- a/nestjs/src/chat/chat.controller.ts
+++ b/nestjs/src/chat/chat.controller.ts
@@ -28,8 +28,11 @@ export class ChatController {
   }
 
   @Post()
-  createChat(@Body() createChatDto: CreateChatDto): Promise<Chat> {
-    return this.chatService.createChat(createChatDto);
+  createChat(
+    @Body() createChatDto: CreateChatDto,
+    @Req() req,
+  ): Promise<(Chat | ChatParticipant)[]> {
+    return this.chatService.createChat(createChatDto, req.user.id);
   }
 
   @Delete('/:id')

--- a/nestjs/src/chat/chat.service.ts
+++ b/nestjs/src/chat/chat.service.ts
@@ -8,7 +8,7 @@ import { ChatParticipantCreateDto } from './dto/chatParticipantCreate.dto';
 import { ChatStatus } from './enum/chat.status.enum';
 import * as bcrypt from 'bcryptjs';
 import { ChatParticipant } from './entities/chatParticipant.entity';
-import { ChatParticipantStatus } from './enum/chatParticipant.status.enum';
+import { ChatParticipantAuthority } from './enum/chatParticipant.authority.enum';
 
 @Injectable()
 export class ChatService {
@@ -84,7 +84,7 @@ export class ChatService {
         );
       } else {
         //ban이 설정되었다가 풀렸을때는 생성하지 않고 update만 해줌
-        participant.status = chatParticipantCreateDto.status;
+        participant.authority = chatParticipantCreateDto.authority;
         return this.chatParticipantRepository.joinAlreadInChat(participant);
       }
     }
@@ -95,10 +95,10 @@ export class ChatService {
     );
   }
 
-  async updateStatus(
+  async updateAuthority(
     user_id: number,
     chat_room_id: number,
-    status: ChatParticipantStatus,
+    authority: ChatParticipantAuthority,
   ) {
     const chatParticipant = await this.chatParticipantRepository
       .createQueryBuilder('cp')
@@ -110,7 +110,7 @@ export class ChatService {
         `Can't find ChatParticipant user_id ${user_id} chat_room_id ${chat_room_id}`,
       );
     }
-    chatParticipant.status = status;
+    chatParticipant.authority = authority;
     return this.chatParticipantRepository.save(chatParticipant);
   }
 

--- a/nestjs/src/chat/chat.service.ts
+++ b/nestjs/src/chat/chat.service.ts
@@ -108,11 +108,12 @@ export class ChatService {
         );
       } else {
         //ban이 설정되었다가 풀렸을때는 생성하지 않고 update만 해줌
-        participant.authority = chatParticipantCreateDto.authority;
+        participant.authority = ChatParticipantAuthority.NORMAL;
         return this.chatParticipantRepository.joinAlreadInChat(participant);
       }
     }
     //최초로 join을 하는 경우
+    chatParticipantCreateDto.authority = ChatParticipantAuthority.NORMAL;
     return this.chatParticipantRepository.joinChat(
       chatParticipantCreateDto,
       user_id,

--- a/nestjs/src/chat/chat.service.ts
+++ b/nestjs/src/chat/chat.service.ts
@@ -79,16 +79,6 @@ export class ChatService {
       .getMany();
   }
 
-  async joinChatAsBoss(
-    chatParticipantCreateDto: ChatParticipantCreateDto,
-    user_id: number,
-  ) {
-    return this.chatParticipantRepository.joinChat(
-      chatParticipantCreateDto,
-      user_id,
-    );
-  }
-
   async joinChat(
     chatParticipantCreateDto: ChatParticipantCreateDto,
     user_id: number,

--- a/nestjs/src/chat/chatParticipant.repository.ts
+++ b/nestjs/src/chat/chatParticipant.repository.ts
@@ -19,11 +19,11 @@ export class ChatParticipantRepository extends Repository<ChatParticipant> {
     chatParticipantCreateDto: ChatParticipantCreateDto,
     user_id: number,
   ) {
-    const { chat_room_id, status } = chatParticipantCreateDto;
+    const { chat_room_id, authority } = chatParticipantCreateDto;
     const participant = this.create({
       chat: { id: chat_room_id },
       user: { id: user_id },
-      status,
+      authority,
     });
     try {
       await this.save(participant);

--- a/nestjs/src/chat/dto/chatJoin.dto.ts
+++ b/nestjs/src/chat/dto/chatJoin.dto.ts
@@ -1,0 +1,13 @@
+import { PickType } from '@nestjs/swagger';
+import { ChatParticipantDto } from './chatParticipant.dto';
+import { IsNotEmpty } from 'class-validator';
+
+export class ChatJoinDto extends PickType(ChatParticipantDto, [
+  'chat_room_id',
+  'authority',
+]) {
+  @IsNotEmpty()
+  chat_room_id: number;
+
+  password: string;
+}

--- a/nestjs/src/chat/dto/chatParticipant.dto.ts
+++ b/nestjs/src/chat/dto/chatParticipant.dto.ts
@@ -1,10 +1,10 @@
-import { ChatParticipantStatus } from '../enum/chatParticipant.status.enum';
+import { ChatParticipantAuthority } from '../enum/chatParticipant.authority.enum';
 
 export class ChatParticipantDto {
   id: number;
   chat_room_id: number;
   user_id: number;
-  status: ChatParticipantStatus;
+  authority: ChatParticipantAuthority;
   ban: Date;
-  status_time: Date;
+  authority_time: Date;
 }

--- a/nestjs/src/chat/dto/chatParticipantCreate.dto.ts
+++ b/nestjs/src/chat/dto/chatParticipantCreate.dto.ts
@@ -1,15 +1,15 @@
 import { PickType } from '@nestjs/swagger';
 import { ChatParticipantDto } from './chatParticipant.dto';
 import { IsNotEmpty } from 'class-validator';
-import { ChatParticipantStatus } from '../enum/chatParticipant.status.enum';
+import { ChatParticipantAuthority } from '../enum/chatParticipant.authority.enum';
 
 export class ChatParticipantCreateDto extends PickType(ChatParticipantDto, [
   'chat_room_id',
-  'status',
+  'authority',
 ]) {
   @IsNotEmpty()
   chat_room_id: number;
 
   @IsNotEmpty()
-  status: ChatParticipantStatus;
+  authority: ChatParticipantAuthority;
 }

--- a/nestjs/src/chat/dto/chatParticipantCreate.dto.ts
+++ b/nestjs/src/chat/dto/chatParticipantCreate.dto.ts
@@ -1,7 +1,6 @@
 import { PickType } from '@nestjs/swagger';
 import { ChatParticipantDto } from './chatParticipant.dto';
 import { IsNotEmpty } from 'class-validator';
-import { ChatParticipantAuthority } from '../enum/chatParticipant.authority.enum';
 
 export class ChatParticipantCreateDto extends PickType(ChatParticipantDto, [
   'chat_room_id',
@@ -9,7 +8,4 @@ export class ChatParticipantCreateDto extends PickType(ChatParticipantDto, [
 ]) {
   @IsNotEmpty()
   chat_room_id: number;
-
-  @IsNotEmpty()
-  authority: ChatParticipantAuthority;
 }

--- a/nestjs/src/chat/entities/chatParticipant.entity.ts
+++ b/nestjs/src/chat/entities/chatParticipant.entity.ts
@@ -1,6 +1,7 @@
 import { User } from 'src/auth/entities/User.entity';
 import {
   BaseEntity,
+  BeforeInsert,
   BeforeUpdate,
   Column,
   Entity,
@@ -33,6 +34,10 @@ export class ChatParticipant extends BaseEntity {
   @Column({ nullable: false })
   authority_time: Date;
 
+  @BeforeInsert()
+  setInitialAuthorityTime() {
+    this.authority_time = new Date();
+  }
   private originalAuthority: ChatParticipantAuthority;
   @BeforeUpdate()
   rememberOriginalStatus() {

--- a/nestjs/src/chat/entities/chatParticipant.entity.ts
+++ b/nestjs/src/chat/entities/chatParticipant.entity.ts
@@ -8,7 +8,7 @@ import {
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { ChatParticipantStatus } from '../enum/chatParticipant.status.enum';
+import { ChatParticipantAuthority } from '../enum/chatParticipant.authority.enum';
 import { Chat } from './chat.entity';
 
 @Entity()
@@ -24,25 +24,25 @@ export class ChatParticipant extends BaseEntity {
   @JoinColumn({ name: 'user_id' })
   user: User;
 
-  @Column({ type: 'enum', enum: ChatParticipantStatus, nullable: false })
-  status: ChatParticipantStatus;
+  @Column({ type: 'enum', enum: ChatParticipantAuthority, nullable: false })
+  authority: ChatParticipantAuthority;
 
   @Column({ nullable: true })
   ban: Date;
 
   @Column({ nullable: false })
-  status_time: Date;
+  authority_time: Date;
 
-  private originalStatus: ChatParticipantStatus;
+  private originalAuthority: ChatParticipantAuthority;
   @BeforeUpdate()
   rememberOriginalStatus() {
-    this.originalStatus = this.status;
+    this.originalAuthority = this.authority;
   }
 
   @BeforeUpdate()
   updateStatusTime() {
-    if (this.status !== this.originalStatus) {
-      this.status_time = new Date();
+    if (this.authority !== this.originalAuthority) {
+      this.authority_time = new Date();
     }
   }
 }

--- a/nestjs/src/chat/enum/chatParticipant.authority.enum.ts
+++ b/nestjs/src/chat/enum/chatParticipant.authority.enum.ts
@@ -1,4 +1,4 @@
-export enum ChatParticipantStatus {
+export enum ChatParticipantAuthority {
   BOSS = 'boss',
   ADMIN = 'admin',
   NORMAL = 'normal',

--- a/nestjs/src/socket/home/home.gateway.ts
+++ b/nestjs/src/socket/home/home.gateway.ts
@@ -50,7 +50,7 @@ export class HomeGateway
   handleMessage(client: any, payload: any): string {
     console.log(payload);
     client
-      .to(payload.roomName)
+      .to(payload.roomId)
       .emit('message', `${client.nickname}: ${payload.inputMessage}`);
     return payload;
   }


### PR DESCRIPTION
## 관련 이슈
- #이슈번호
#60 
## 요약
protected, public 채팅방 입장 로직 추가
<br><br>

## 작업내용
- protected 채팅방에 참여할때는 데이터베이스에 해시되어 저장되어있는 비밀번호와 compare하여 참여 여부를 결정함
- joinAlreadyExistChat, joinNotExistChat 함수 이용하여 joinChat 함수 리팩터링
<br><br>

## 참고사항
- ChatJoinDto 추가하였습니다.
- service단에서 함수를 쪼개고있는데 가독성 좋은지 판단좀 부탁드립니다. 처음 해보는거라서 이런식으로 나누는게 맞나 싶네요
<br><br>
