### PR TITLE
Feat chat테이블 delete query fail 오류

### DIFF
--- a/nestjs/src/chat/chat.service.ts
+++ b/nestjs/src/chat/chat.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Injectable,
   NotFoundException,
   UnauthorizedException,
@@ -8,7 +9,6 @@ import { ChatRepository } from './chat.respository';
 import { ChatParticipantRepository } from './chatParticipant.repository';
 import { CreateChatDto } from './dto/chatCreate.dto';
 import { Chat } from './entities/chat.entity';
-import { ChatParticipantCreateDto } from './dto/chatParticipantCreate.dto';
 import { ChatStatus } from './enum/chat.status.enum';
 import * as bcrypt from 'bcryptjs';
 import { ChatParticipant } from './entities/chatParticipant.entity';
@@ -134,10 +134,21 @@ export class ChatService {
     }
   }
 
+  async checkChatExist(id: number) {
+    if (
+      !(await this.chatParticipantRepository.findOneBy({
+        id,
+      }))
+    ) {
+      throw new BadRequestException(`Chat room id ${id} does not exist`);
+    }
+  }
+
   async joinChat(
     chatJoinDto: ChatJoinDto,
     user_id: number,
   ): Promise<ChatParticipant> {
+    this.checkChatExist(chatJoinDto.chat_room_id);
     const participant = await this.chatParticipantRepository
       .createQueryBuilder('cp')
       .where('cp.chat_room_id = :id', {
@@ -171,6 +182,7 @@ export class ChatService {
     authority: ChatParticipantAuthority,
     request_user_id: number,
   ) {
+    this.checkChatExist(chat_room_id);
     this.checkAdminOrBoss(request_user_id, chat_room_id);
     const chatParticipant = await this.chatParticipantRepository
       .createQueryBuilder('cp')
@@ -191,6 +203,7 @@ export class ChatService {
     chat_room_id: number,
     request_user_id: number,
   ) {
+    this.checkChatExist(chat_room_id);
     this.checkAdminOrBoss(request_user_id, chat_room_id);
     const chatParticipant = await this.chatParticipantRepository
       .createQueryBuilder('cp')
@@ -214,6 +227,7 @@ export class ChatService {
     chat_room_id: number,
     request_user_id: number,
   ) {
+    this.checkChatExist(chat_room_id);
     this.checkAdminOrBoss(request_user_id, chat_room_id);
     const chatParticipant = await this.chatParticipantRepository
       .createQueryBuilder('cp')

--- a/nestjs/src/chat/entities/chat.entity.ts
+++ b/nestjs/src/chat/entities/chat.entity.ts
@@ -3,15 +3,22 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
 import { ChatStatus } from '../enum/chat.status.enum';
+import { ChatParticipant } from './chatParticipant.entity';
 
 @Entity()
 export class Chat extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
+
+  @OneToMany(() => ChatParticipant, chatParticipant => chatParticipant.chat, {
+    cascade: true,
+  })
+  chatParticipants: ChatParticipant[];
 
   @Column({ nullable: false })
   room_name: string;

--- a/nestjs/src/chat/entities/chatParticipant.entity.ts
+++ b/nestjs/src/chat/entities/chatParticipant.entity.ts
@@ -17,7 +17,7 @@ export class ChatParticipant extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ManyToOne(() => Chat)
+  @ManyToOne(() => Chat, chat => chat.chatParticipants, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'chat_room_id' })
   chat: Chat;
 


### PR DESCRIPTION
## 관련 이슈
- #이슈번호
#65 
## 요약
chat테이블 삭제시 chatParticipant FK로 인한 오류 수정
<br><br>

## 작업내용
- Chat Entity에서 OneToMany 데코레이터 추가 후 cascade: true 설정
- ChatParticipant Entity에서 ManyToOne 데코레이터에서 { onDelete: 'CASCADE' } 추가
<br><br>

## 참고사항
- Chat, ChatParticipant table에 대한 무결성을 좀더 고려해봐야 할 것 같습니다
<br><br>
