### PR TITLE
Hotfix 비밀번호 null검증방식 변경

### DIFF
--- a/nestjs/src/chat/chat.service.ts
+++ b/nestjs/src/chat/chat.service.ts
@@ -26,11 +26,11 @@ export class ChatService {
 
   checkChatStatusAndPassword(status: ChatStatus, password: string) {
     if (status === ChatStatus.PROTECTED) {
-      if (password === null) {
+      if (password.trim() === '') {
         throw new BadRequestException('Protected room require password');
       }
     } else {
-      if (password !== null) {
+      if (password.trim() !== '') {
         throw new BadRequestException(`${status} room do not require password`);
       }
     }

--- a/nestjs/src/socket/home/home.gateway.ts
+++ b/nestjs/src/socket/home/home.gateway.ts
@@ -55,6 +55,15 @@ export class HomeGateway
     return payload;
   }
 
+  @SubscribeMessage('deleteRoom')
+  handleOutOfRoom(client: any, payload: any): void {
+    console.log('delete room event');
+    console.log(payload);
+    client
+      .to(payload.roomId)
+      .emit('deleteRoom', `roomId ${payload.roomId} deleted`);
+  }
+
   @SubscribeMessage('enterRoom')
   handleEnterRoom(client: any, roomId: number) {
     const currentRooms = client.rooms;


### PR DESCRIPTION
## 관련 이슈

## 요약
비밀번호 null검증방식 변경
<br><br>

## 작업내용
- 프론트앤드에서 null로 password를 넘기는게 불가능함으로 null이 아닌 trim함수를 통한 빈문자열로 null 판단
<br><br>

## 참고사항

<br><br>
