### PR TITLE
[Feat]: 채팅방 참여 기능 수정및 추가

### DIFF
--- a/nestjs/src/chat/chat.controller.ts
+++ b/nestjs/src/chat/chat.controller.ts
@@ -48,11 +48,16 @@ export class ChatController {
     return this.chatService.updateChat(id, createChatDto);
   }
 
-  @Get('participant/:user_id')
-  getMyChatRoom(
-    @Param('user_id', ParseIntPipe) user_id,
+  @Get('participant/')
+  getMyChatRoom(@Req() req): Promise<ChatParticipant[]> {
+    return this.chatService.getMyChatRoom(req.user.id);
+  }
+
+  @Get('participant/:chat_room_id')
+  getChatRoomByChatId(
+    @Param('chat_room_id', ParseIntPipe) chat_room_id,
   ): Promise<ChatParticipant[]> {
-    return this.chatService.getMyChatRoom(user_id);
+    return this.chatService.getChatRoomByChatId(chat_room_id);
   }
 
   @Post('participant')
@@ -84,16 +89,16 @@ export class ChatController {
     return this.chatService.updateBan(user_id, chat_room_id, req.user.id);
   }
 
-  @Patch('participant/notban/:user_id/:chat_room_id')
-  switchNotBan(
+  @Patch('participant/unban/:user_id/:chat_room_id')
+  switchUnBan(
     @Param('user_id', ParseIntPipe) user_id: number,
     @Param('chat_room_id', ParseIntPipe) chat_room_id: number,
     @Req() req,
   ) {
-    return this.chatService.updateNotBan(user_id, chat_room_id, req.user.id);
+    return this.chatService.updateUnBan(user_id, chat_room_id, req.user.id);
   }
 
-  @Delete('/:user_id/:chat_room_id')
+  @Delete('participant/:user_id/:chat_room_id')
   deleteCharParticipant(
     @Param('user_id', ParseIntPipe) user_id: number,
     @Param('chat_room_id', ParseIntPipe) chat_room_id: number,

--- a/nestjs/src/chat/chat.service.ts
+++ b/nestjs/src/chat/chat.service.ts
@@ -103,6 +103,14 @@ export class ChatService {
       .getMany();
   }
 
+  async getChatRoomByChatId(chat_room_id: number): Promise<ChatParticipant[]> {
+    return this.chatParticipantRepository
+      .createQueryBuilder('cp')
+      .innerJoin('cp.chat', 'c')
+      .where('c.id = :id', { id: chat_room_id })
+      .getMany();
+  }
+
   async joinAlreadyExistChat(
     participant: ChatParticipant,
     user_id: number,
@@ -245,7 +253,7 @@ export class ChatService {
     return this.chatParticipantRepository.save(chatParticipant);
   }
 
-  async updateNotBan(
+  async updateUnBan(
     user_id: number,
     chat_room_id: number,
     request_user_id: number,


### PR DESCRIPTION
## 관련 이슈
- #이슈번호
74
## 요약
채팅방 참여 기능 수정 및 추가
<br><br>

## 작업내용
- (GET) api/chat/participant/{user_id} 에서 {user_id} 빼고 토큰으로 확인하도록 변경
- 채팅방 참여자 목록을 반환하는 API추가 --> /api/chat/participant/{chat_room_id}
- API path: notban --> unban으로 변경
- 채팅방 참여자 삭제 API에 path로 participant/ 추가
<br><br>

## 참고사항

<br><br>
