### PR TITLE
[Fix]: Password는 query select에서 제외

### DIFF
--- a/nestjs/src/chat/entities/chat.entity.ts
+++ b/nestjs/src/chat/entities/chat.entity.ts
@@ -26,7 +26,7 @@ export class Chat extends BaseEntity {
   @Column({ type: 'enum', enum: ChatStatus, nullable: false })
   status: ChatStatus;
 
-  @Column({ nullable: true })
+  @Column({ nullable: true, select: false })
   password: string;
 
   @CreateDateColumn()


### PR DESCRIPTION
## 요약
typeORM의 Column 데코레이터에서 select: false 처리를 통해 프론트앤드로 전송이 안되도록 변경