### PR TITLE
[feat]: 다중 로그인 방지 처리

### DIFF
--- a/nestjs/src/auth/auth.module.ts
+++ b/nestjs/src/auth/auth.module.ts
@@ -8,6 +8,7 @@ import { User } from './entities/User.entity';
 import { UserRepository } from './user.repository';
 import { MulterModules } from 'src/multer/multer.module';
 import { NormalJwtModule } from 'src/jwt/jwt.module';
+import { HomeModule } from 'src/socket/home/home.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { NormalJwtModule } from 'src/jwt/jwt.module';
     TempJwtModule,
     TypeOrmModule.forFeature([User]),
     MulterModules,
+    HomeModule,
   ],
   controllers: [AuthController],
   providers: [AuthService, UserRepository],

--- a/nestjs/src/filter/oauth-exception.filter.ts
+++ b/nestjs/src/filter/oauth-exception.filter.ts
@@ -1,6 +1,7 @@
 import {
   ArgumentsHost,
   Catch,
+  ConflictException,
   ExceptionFilter,
   HttpStatus,
 } from '@nestjs/common';
@@ -11,10 +12,13 @@ export class OauthExceptionFilter implements ExceptionFilter {
   catch(exception: unknown, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response: Response = ctx.getResponse();
+    let message = 'Oauth 로그인 실패...';
+    if (exception instanceof ConflictException)
+      message = '이미 로그인 되어 있는 회원입니다.';
     response
       .status(HttpStatus.FOUND)
       .send(
-        `<script type="text/javascript">alert('Oauth 로그인 실패..'); window.location.href='http://localhost:4000/login' </script>`,
+        `<script type="text/javascript">alert('${message}'); window.location.href='http://localhost:4000/login' </script>`,
       );
   }
 }

--- a/nestjs/src/socket/home/connection.service.ts
+++ b/nestjs/src/socket/home/connection.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { Socket } from 'socket.io';
+
+@Injectable()
+export class ConnectionService {
+  private userConnections: Map<number, Socket> = new Map();
+
+  findUserConnection(userId: number): boolean {
+    if (this.userConnections.has(userId)) return true;
+    else return false;
+  }
+
+  addUserConnection(userId: number, socket: Socket): boolean {
+    if (this.findUserConnection(userId)) return false;
+    this.userConnections.set(userId, socket);
+    return true;
+  }
+
+  removeUserConnection(userId: number): void {
+    this.userConnections.delete(userId);
+  }
+}

--- a/nestjs/src/socket/home/home.module.ts
+++ b/nestjs/src/socket/home/home.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { HomeGateway } from './home.gateway';
 import { NormalJwtModule } from 'src/jwt/jwt.module';
-import { PassportsModule } from 'src/passports/passports.module';
+import { ConnectionService } from './connection.service';
 
 @Module({
-  imports: [PassportsModule, NormalJwtModule],
-  providers: [HomeGateway],
+  imports: [NormalJwtModule],
+  providers: [HomeGateway, ConnectionService],
+  exports: [ConnectionService],
 })
 export class HomeModule {}


### PR DESCRIPTION
## 관련 이슈
- #81 

## 요약
- 다중 로그인 방지 처리를 하는 코드가 추가 되었습니다.
- Login시에 다중 로그인시 error 메세지를 추가하였습니다.

<br><br>

## 작업내용
- 유저와 소켓 정보를 저장하는 ConnectionService 추가
- Oauth 로그인시에 error 메시지 수정
- 소켓 connect, disconnect 시에 ConnectionService에 있는 소켓 정보 제거

<br><br>

## 참고사항

<br><br>
