### PR TITLE
Feat 79 알림 서비스 처리 및 유저 상태 확인

### DIFF
--- a/nestjs/src/auth/auth.module.ts
+++ b/nestjs/src/auth/auth.module.ts
@@ -8,6 +8,7 @@ import { User } from './entities/User.entity';
 import { UserRepository } from './user.repository';
 import { MulterModules } from 'src/multer/multer.module';
 import { NormalJwtModule } from 'src/jwt/jwt.module';
+import { HomeModule } from 'src/socket/home/home.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { NormalJwtModule } from 'src/jwt/jwt.module';
     TempJwtModule,
     TypeOrmModule.forFeature([User]),
     MulterModules,
+    HomeModule,
   ],
   controllers: [AuthController],
   providers: [AuthService, UserRepository],

--- a/nestjs/src/filter/oauth-exception.filter.ts
+++ b/nestjs/src/filter/oauth-exception.filter.ts
@@ -1,6 +1,7 @@
 import {
   ArgumentsHost,
   Catch,
+  ConflictException,
   ExceptionFilter,
   HttpStatus,
 } from '@nestjs/common';
@@ -11,10 +12,13 @@ export class OauthExceptionFilter implements ExceptionFilter {
   catch(exception: unknown, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response: Response = ctx.getResponse();
+    let message = 'Oauth 로그인 실패...';
+    if (exception instanceof ConflictException)
+      message = '이미 로그인 되어 있는 회원입니다.';
     response
       .status(HttpStatus.FOUND)
       .send(
-        `<script type="text/javascript">alert('Oauth 로그인 실패..'); window.location.href='http://localhost:4000/login' </script>`,
+        `<script type="text/javascript">alert('${message}'); window.location.href='http://localhost:4000/login' </script>`,
       );
   }
 }

--- a/nestjs/src/friend/dto/friendGetResponse.dto.ts
+++ b/nestjs/src/friend/dto/friendGetResponse.dto.ts
@@ -1,5 +1,12 @@
+export enum FriendStatus {
+  Online = 'online',
+  Offline = 'offline',
+  Gaming = 'gaming',
+}
+
 export default class FriendGetResponseDto {
   nickname: string;
   id: number;
   avata_path: string;
+  status: FriendStatus;
 }

--- a/nestjs/src/friend/dto/friendRequestingAlarms.dto.ts
+++ b/nestjs/src/friend/dto/friendRequestingAlarms.dto.ts
@@ -1,0 +1,8 @@
+import { FriendRequestStatus } from 'src/profile/dto/searchUser.dto';
+
+export default class FriendRequestingAlarmsDto {
+  id: number;
+  nickname: string;
+  avata_path: string;
+  status: FriendRequestStatus;
+}

--- a/nestjs/src/friend/friend.controller.ts
+++ b/nestjs/src/friend/friend.controller.ts
@@ -20,6 +20,7 @@ import { UnauthorizedExceptionFilter } from 'src/filter/unauthorized-exception.f
 import { RequestStatus } from './entities/FriendRequesting.entity';
 import FriendCommonRequestBodyDto from './dto/friendCommonRequestBody.dto';
 import FriendGetResponseDto from './dto/friendGetResponse.dto';
+import FriendRequestingAlarmsDto from './dto/friendRequestingAlarms.dto';
 
 @Controller('friend')
 @UseFilters(new UnauthorizedExceptionFilter())
@@ -34,6 +35,14 @@ export class FriendController {
       user.id,
     );
     return friends;
+  }
+
+  @Get('alarms')
+  async getFriendRequest(
+    @Req() req: Request,
+  ): Promise<FriendRequestingAlarmsDto[]> {
+    const user: any = req.user;
+    return this.friendService.getFriendRequest(user.id);
   }
 
   @Post('request')

--- a/nestjs/src/friend/friend.module.ts
+++ b/nestjs/src/friend/friend.module.ts
@@ -9,11 +9,13 @@ import { FriendController } from './friend.controller';
 import { UserRepository } from 'src/auth/user.repository';
 import { User } from 'src/auth/entities/User.entity';
 import { PassportsModule } from 'src/passports/passports.module';
+import { HomeModule } from 'src/socket/home/home.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([User, Friends, FriendRequesting]),
     PassportsModule,
+    HomeModule,
   ],
   controllers: [FriendController],
   providers: [

--- a/nestjs/src/friend/friendRequesting.repository.ts
+++ b/nestjs/src/friend/friendRequesting.repository.ts
@@ -19,6 +19,27 @@ export class FriendRequestingRepository extends Repository<FriendRequesting> {
     );
   }
 
+  async getFriendRequest(userId: number): Promise<FriendRequesting[]> {
+    const search_result: FriendRequesting[] =
+      await this.friendRequestingRepository.find({
+        relations: {
+          from_user_id: true,
+          to_user_id: true,
+        },
+        where: [
+          {
+            from_user_id: { id: userId },
+            status: RequestStatus.Requesting,
+          },
+          {
+            to_user_id: { id: userId },
+            status: RequestStatus.Requesting,
+          },
+        ],
+      });
+    return search_result;
+  }
+
   async updateRequest(request: FriendRequesting): Promise<void> {
     try {
       this.friendRequestingRepository.save(request);

--- a/nestjs/src/friend/friends.repository.ts
+++ b/nestjs/src/friend/friends.repository.ts
@@ -15,4 +15,22 @@ export class FriendsRepository extends Repository<Friends> {
       friendsRepository.queryRunner,
     );
   }
+
+  async getFriend(userId: number): Promise<Friends[]> {
+    const search_result: Friends[] = await this.friendsRepository.find({
+      relations: {
+        user_id1: true,
+        user_id2: true,
+      },
+      where: [
+        {
+          user_id1: { id: userId },
+        },
+        {
+          user_id2: { id: userId },
+        },
+      ],
+    });
+    return search_result;
+  }
 }

--- a/nestjs/src/profile/dto/searchUser.dto.ts
+++ b/nestjs/src/profile/dto/searchUser.dto.ts
@@ -3,7 +3,7 @@ import { PickType } from '@nestjs/swagger';
 import { IsNotEmpty } from 'class-validator';
 import { Expose, Transform } from 'class-transformer';
 
-export enum SearchUserRequestStatus {
+export enum FriendRequestStatus {
   Allow = 'allow',
   SendRequest = 'send',
   RecvRequest = 'recv',
@@ -25,5 +25,5 @@ export default class SearchUserDto extends PickType(UserDto, [
   @Expose()
   avata_path: string;
 
-  friend_status: SearchUserRequestStatus;
+  friend_status: FriendRequestStatus;
 }

--- a/nestjs/src/profile/profile.service.ts
+++ b/nestjs/src/profile/profile.service.ts
@@ -21,7 +21,7 @@ import { FriendRequestingRepository } from 'src/friend/friendRequesting.reposito
 import { NormalJwt } from 'src/jwt/interface/jwt.type';
 import JwtPayload from 'src/passports/interface/jwtPayload.interface';
 import MyInfoDto from './dto/myInfo.dto';
-import SearchUserDto, { SearchUserRequestStatus } from './dto/searchUser.dto';
+import SearchUserDto, { FriendRequestStatus } from './dto/searchUser.dto';
 import { UpdateUserDto } from './dto/userUpdate.dto';
 
 @Injectable()
@@ -59,12 +59,12 @@ export class ProfileService {
       await this.friendRequestingRepository.findPrevRequest(my_id, profile.id);
     switch (prev_request?.status) {
       case RequestStatus.Allow:
-        result.friend_status = SearchUserRequestStatus.Allow;
+        result.friend_status = FriendRequestStatus.Allow;
         break;
       case RequestStatus.Requesting:
         if (prev_request.to_user_id.id === my_id)
-          result.friend_status = SearchUserRequestStatus.RecvRequest;
-        else result.friend_status = SearchUserRequestStatus.SendRequest;
+          result.friend_status = FriendRequestStatus.RecvRequest;
+        else result.friend_status = FriendRequestStatus.SendRequest;
         break;
     }
     return result;

--- a/nestjs/src/socket/home/connection.service.ts
+++ b/nestjs/src/socket/home/connection.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { Socket } from 'socket.io';
+
+@Injectable()
+export class ConnectionService {
+  private userConnections: Map<number, Socket> = new Map();
+
+  findUserConnection(userId: number): boolean {
+    if (this.userConnections.has(userId)) return true;
+    else return false;
+  }
+
+  addUserConnection(userId: number, socket: Socket): boolean {
+    if (this.findUserConnection(userId)) return false;
+    this.userConnections.set(userId, socket);
+    return true;
+  }
+
+  removeUserConnection(userId: number): void {
+    this.userConnections.delete(userId);
+  }
+}

--- a/nestjs/src/socket/home/home.module.ts
+++ b/nestjs/src/socket/home/home.module.ts
@@ -1,7 +1,11 @@
 import { Module } from '@nestjs/common';
 import { HomeGateway } from './home.gateway';
+import { NormalJwtModule } from 'src/jwt/jwt.module';
+import { ConnectionService } from './connection.service';
 
 @Module({
-  providers: [HomeGateway],
+  imports: [NormalJwtModule],
+  providers: [HomeGateway, ConnectionService],
+  exports: [ConnectionService],
 })
 export class HomeModule {}


### PR DESCRIPTION
## 관련 이슈
- #79 

## 요약
- 알람 서비스 처리 및 유저 상태 확인 처리 기능 추가

<br><br>

## 작업내용
- SearchUserRequestStatus enum명에서 FriendRequestStatus로 좀 명확하게 이름을 변경했습니다.
- 다중 로그인 방지 처리를 하는 코드가 추가 되었습니다.
- Login시에 다중 로그인시 error 메세지를 추가하였습니다.
=> 기능 작동을 위해서 user에도 추가했습니다
- getFriend시에 친구의 상태를 socket map 에서 검색해서 online, offline을 return
   => 추후에 game status도 확인하여 게임중 상태도 표시할 예정
- /friend/alarms API 추가
   => 해당 user에 친구 요청 목록을 조회해서 가져오기


<br><br>

## 참고사항

<br><br>
