### PR TITLE
[Feat]: BOSS가 방을 나갔을때 처리

### DIFF
--- a/nestjs/src/chat/chat.controller.ts
+++ b/nestjs/src/chat/chat.controller.ts
@@ -15,8 +15,8 @@ import { AuthGuard } from '@nestjs/passport';
 import { CreateChatDto } from './dto/chatCreate.dto';
 import { Chat } from './entities/chat.entity';
 import { ChatParticipant } from './entities/chatParticipant.entity';
-import { ChatParticipantAuthority } from './enum/chatParticipant.authority.enum';
 import { ChatJoinDto } from './dto/chatJoin.dto';
+import { ChatParticipantAuthorityDto } from './dto/chatParticipantAuthority.dto';
 
 @Controller('chat')
 @UseGuards(AuthGuard('jwt'))
@@ -62,26 +62,30 @@ export class ChatController {
   }
 
   @Post('participant/permission')
-  isUserJoinableChatRoom(@Body() chatJoinDto: ChatJoinDto, @Req() req) {
+  isUserJoinableChatRoom(
+    @Body() chatJoinDto: ChatJoinDto,
+    @Req() req,
+  ): Promise<ChatParticipant> {
     return this.chatService.isUserJoinableChatRoom(req.user.id, chatJoinDto);
   }
 
   @Post('participant')
-  joinChat(@Body() chatJoinDto: ChatJoinDto, @Req() req) {
+  joinChat(
+    @Body() chatJoinDto: ChatJoinDto,
+    @Req() req,
+  ): Promise<ChatParticipant> {
     return this.chatService.joinChat(chatJoinDto, req.user.id);
   }
 
-  @Patch('participant/authority/:target_user_id/:chat_room_id')
+  @Patch('participant/authority/:target_user_id/')
   switchAuthority(
     @Param('target_user_id', ParseIntPipe) target_user_id: number,
-    @Param('chat_room_id', ParseIntPipe) chat_room_id: number,
-    @Body() authority: ChatParticipantAuthority,
+    @Body() chatParticipantAuthorityDto: ChatParticipantAuthorityDto,
     @Req() req,
-  ) {
+  ): Promise<ChatParticipant> {
     return this.chatService.updateAuthority(
       target_user_id,
-      chat_room_id,
-      authority,
+      chatParticipantAuthorityDto,
       req.user.id,
     );
   }
@@ -91,7 +95,7 @@ export class ChatController {
     @Param('target_user_id', ParseIntPipe) target_user_id: number,
     @Param('chat_room_id', ParseIntPipe) chat_room_id: number,
     @Req() req,
-  ) {
+  ): Promise<ChatParticipant> {
     return this.chatService.switchBan(
       target_user_id,
       chat_room_id,
@@ -104,7 +108,7 @@ export class ChatController {
     @Param('target_user_id', ParseIntPipe) target_user_id: number,
     @Param('chat_room_id', ParseIntPipe) chat_room_id: number,
     @Req() req,
-  ) {
+  ): Promise<ChatParticipant> {
     return this.chatService.switchUnBan(
       target_user_id,
       chat_room_id,
@@ -112,16 +116,24 @@ export class ChatController {
     );
   }
 
-  @Delete('participant/:target_user_id/:chat_room_id')
-  deleteChatParticipant(
+  @Delete('participant/leave/:chat_room_id')
+  leaveChatParticipant(
+    @Param('chat_room_id', ParseIntPipe) chat_room_id: number,
+    @Req() req,
+  ): Promise<void> {
+    return this.chatService.leaveChatParticipant(chat_room_id, req.user.id);
+  }
+
+  @Delete('participant/kick/:target_user_id/:chat_room_id')
+  kickChatParticipant(
     @Param('target_user_id', ParseIntPipe) target_user_id: number,
     @Param('chat_room_id', ParseIntPipe) chat_room_id: number,
     @Req() req,
   ): Promise<void> {
-    return this.chatService.deleteChatParticipant(
+    return this.chatService.kickChatParticipant(
       target_user_id,
       chat_room_id,
-      req.user.user_id,
+      req.user.id,
     );
   }
 }

--- a/nestjs/src/chat/dto/chatParticipantAuthority.dto.ts
+++ b/nestjs/src/chat/dto/chatParticipantAuthority.dto.ts
@@ -1,0 +1,15 @@
+import { PickType } from '@nestjs/swagger';
+import { ChatParticipantDto } from './chatParticipant.dto';
+import { IsNotEmpty } from 'class-validator';
+import { ChatParticipantAuthority } from '../enum/chatParticipant.authority.enum';
+
+export class ChatParticipantAuthorityDto extends PickType(ChatParticipantDto, [
+  'chat_room_id',
+  'authority',
+]) {
+  @IsNotEmpty()
+  chat_room_id: number;
+
+  @IsNotEmpty()
+  authority: ChatParticipantAuthority;
+}


### PR DESCRIPTION
## 관련 이슈
- #이슈번호
close #117 
## 요약
BOSS가 채팅방을 나갔을때에 대한 처리
<br><br>

## 작업내용
- chatParticipant 테이블의 delete를 kick, leave 두가지 경우로 분리
- kick은 요청한 유저의 권한도 확인 (Boss or Admin)
- chatJoin함수에서 ban 권한을 확인하는 로직 삭제(임시 주석처리 추후 삭제예정)
<br><br>

## 참고사항

<br><br>
