### PR TITLE
Hotfix 116 unauthorizedexceptionfilter 예외 처리

### DIFF
--- a/nestjs/src/filter/unauthorized-exception.filter.ts
+++ b/nestjs/src/filter/unauthorized-exception.filter.ts
@@ -5,20 +5,17 @@ import {
   UnauthorizedException,
   HttpStatus,
 } from '@nestjs/common';
-import unauthorizedException from './interface/unauthorized.interface';
+import { Response } from 'express';
 
 @Catch(UnauthorizedException)
 export class UnauthorizedExceptionFilter implements ExceptionFilter {
   catch(exception: UnauthorizedException, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
-    const response = ctx.getResponse();
-    const result: unauthorizedException = {
-      statusCode: HttpStatus.UNAUTHORIZED,
-      message: 'UNAUTHORIZED',
-    };
-    response
-      .clearCookie('access_token')
-      .status(HttpStatus.UNAUTHORIZED)
-      .json(result);
+    const response: Response = ctx.getResponse();
+    if (exception.message === 'Unauthorized') {
+      response.clearCookie('access_token');
+      exception.message = 'UNAUTHORIZED';
+    }
+    response.status(HttpStatus.UNAUTHORIZED).json(exception.getResponse());
   }
 }

--- a/nestjs/src/filter/unauthorized-exception.filter.ts
+++ b/nestjs/src/filter/unauthorized-exception.filter.ts
@@ -16,6 +16,9 @@ export class UnauthorizedExceptionFilter implements ExceptionFilter {
       response.clearCookie('access_token');
       exception.message = 'UNAUTHORIZED';
     }
-    response.status(HttpStatus.UNAUTHORIZED).json(exception.getResponse());
+    response.status(HttpStatus.UNAUTHORIZED).json({
+      statusCode: HttpStatus.UNAUTHORIZED,
+      message: exception.message,
+    });
   }
 }


### PR DESCRIPTION
## 관련 이슈
- #116

## 요약
- UnauthorizedExceptionFilter 예외 처리

<br><br>

## 작업내용
- UnauthorizedException을 return 해야 되는 상황이 존재할 수 있음. 예) 잘못된 패스워드 값 입력 등
- jwt 토큰 UnauthorizedException일때를 확인해서 clearCookie 처리

<br><br>

## 참고사항
- unauthorizedException의 message 기본값은 'Unauthorized' 임.
- throw new unauthorizedException('에러 메세지') 시에 앞에 처럼 무조건 에러 메세지를 남겨야함

<br><br>
