### PR TITLE
[fix] emit과 disconnect를 timeout 설정

### DIFF
--- a/nestjs/src/socket/home/home.gateway.ts
+++ b/nestjs/src/socket/home/home.gateway.ts
@@ -61,8 +61,10 @@ export class HomeGateway
         console.log(`home socket: ${client.id} connected`);
         client.emit('connection', '서버에 접속하였습니다');
       } else {
-        client.emit('multipleConnect', '다중 로그인');
-        client.disconnect(true);
+        setTimeout(() => {
+          client.emit('multipleConnect', '다중 로그인');
+          client.disconnect(true);
+        }, 500);
       }
     } else client.disconnect(true);
   }


### PR DESCRIPTION
## 관련 이슈
- #112 

## 요약
- 다중 로그인 예외 처리

<br><br>

## 작업내용
- timeout 설정을 하지 않으면, client의 event listener가 설정되기 전에 메세지가 전송될 수 있음. 이를 방지하기 위해 약 500ms 이후에 요청을 보내도록 설정

<br><br>

## 참고사항

<br><br>
