### PR TITLE
Feat 126 mute기능 추가

### DIFF
--- a/nestjs/src/chat/chatParticipant.repository.ts
+++ b/nestjs/src/chat/chatParticipant.repository.ts
@@ -43,7 +43,7 @@ export class ChatParticipantRepository extends Repository<ChatParticipant> {
 
   getChatParticipantByUserChatRoom(
     user_id: number,
-    chat_room_id,
+    chat_room_id: number,
   ): Promise<ChatParticipant> {
     return this.createQueryBuilder('cp')
       .where('cp.user_id = :user_id', { user_id })

--- a/nestjs/src/socket/home/dto/mute.dto.ts
+++ b/nestjs/src/socket/home/dto/mute.dto.ts
@@ -1,0 +1,4 @@
+export class MuteDto {
+  roomId: string;
+  target_user_id: string;
+}

--- a/nestjs/src/socket/home/home.module.ts
+++ b/nestjs/src/socket/home/home.module.ts
@@ -2,10 +2,22 @@ import { Module } from '@nestjs/common';
 import { HomeGateway } from './home.gateway';
 import { NormalJwtModule } from 'src/jwt/jwt.module';
 import { ConnectionService } from './connection.service';
+import { ChatParticipantRepository } from 'src/chat/chatParticipant.repository';
+import { ChatRepository } from 'src/chat/chat.respository';
+import { MessageService } from './message.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Chat } from 'src/chat/entities/chat.entity';
+import { ChatParticipant } from 'src/chat/entities/chatParticipant.entity';
 
 @Module({
-  imports: [NormalJwtModule],
-  providers: [HomeGateway, ConnectionService],
-  exports: [ConnectionService],
+  imports: [NormalJwtModule, TypeOrmModule.forFeature([Chat, ChatParticipant])],
+  providers: [
+    HomeGateway,
+    ConnectionService,
+    MessageService,
+    ChatParticipantRepository,
+    ChatRepository,
+  ],
+  exports: [ConnectionService, MessageService],
 })
 export class HomeModule {}

--- a/nestjs/src/socket/home/message.service.ts
+++ b/nestjs/src/socket/home/message.service.ts
@@ -1,0 +1,79 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Socket } from 'socket.io';
+import { ChatRepository } from 'src/chat/chat.respository';
+import { ChatParticipantRepository } from 'src/chat/chatParticipant.repository';
+import { ChatParticipantAuthority } from 'src/chat/enum/chatParticipant.authority.enum';
+import { parse } from 'cookie';
+import { NormalJwt } from 'src/jwt/interface/jwt.type';
+import { JwtService } from '@nestjs/jwt';
+import { MuteDto } from './dto/mute.dto';
+
+@Injectable()
+export class MessageService {
+  constructor(
+    @Inject(NormalJwt)
+    private readonly jwtService: JwtService,
+    @InjectRepository(ChatRepository)
+    private chatRepository: ChatRepository,
+    @InjectRepository(ChatParticipantRepository)
+    private chatParticipantRepository: ChatParticipantRepository,
+  ) {}
+  //           Map<[user_id, chat_room_id], true/false>
+  private mute: Map<[string, string], boolean> = new Map();
+  getJwt(client: Socket) {
+    let jwt = null;
+    if (client.handshake.headers?.cookie) {
+      const token = parse(client.handshake.headers.cookie).access_token;
+      try {
+        jwt = this.jwtService.verify(token);
+      } catch (error: any) {
+        jwt = null;
+      }
+    }
+    return jwt;
+  }
+
+  async isBossOrAdmin(user_id: number, roomId: number) {
+    let result = false;
+
+    const requestUser =
+      await this.chatParticipantRepository.getChatParticipantByUserChatRoom(
+        user_id,
+        roomId,
+      );
+    if (
+      requestUser &&
+      !(requestUser.authority === ChatParticipantAuthority.NORMAL)
+    ) {
+      result = true;
+    }
+
+    return result;
+  }
+
+  async muteUser(muteDto: MuteDto): Promise<string> {
+    if (
+      await this.chatParticipantRepository.getChatParticipantByUserChatRoom(
+        parseInt(muteDto.target_user_id),
+        parseInt(muteDto.roomId),
+      )
+    ) {
+      const muteUser = this.mute.get([muteDto.target_user_id, muteDto.roomId]);
+      if (!muteUser) {
+        this.mute.set([muteDto.target_user_id, muteDto.roomId], true);
+        setTimeout(() => {
+          this.mute.delete([muteDto.target_user_id, muteDto.roomId]);
+        }, 10000); //10초동안 mute
+        return `user ${muteDto.target_user_id} is muted`;
+      } else {
+        return `user ${muteDto.target_user_id} is already muted`;
+      }
+    }
+    return `user ${muteDto.target_user_id} is not in chat room id ${muteDto.roomId}`;
+  }
+
+  isImMute(user_id: string, chat_room_id: string): boolean {
+    return this.mute.get([user_id, chat_room_id]);
+  }
+}


### PR DESCRIPTION
## 관련 이슈
- #이슈번호
#126 
## 요약
채팅방 mute기능을 추가했습니다
<br><br>

## 작업내용
- messageService.ts파일에서 Map자료구조로 mute상태 관리
- setTimeout 10초 후 Map자료구조에서 mute를 해제해줌
- mute를 명령한 사용자의 jwt를 확인하여 DB에서 boss or admin인지 권한을 확인
<br><br>

## 참고사항
- handleConnection 함수에서 jwt를 받아오는 로직을 따로 messageService.ts파일로 뺐습니다.
- 지금은 10초 mute인데 협의 후 바꿀 수 있습니다.
<br><br>
