### PR TITLE
[Fix]: 채팅방 수정, 삭제 API

### DIFF
--- a/nestjs/src/chat/chat.controller.ts
+++ b/nestjs/src/chat/chat.controller.ts
@@ -35,17 +35,13 @@ export class ChatController {
     return this.chatService.createChat(createChatDto, req.user.id);
   }
 
-  @Delete('/:id')
-  deleteChat(@Param('id', ParseIntPipe) id): Promise<void> {
-    return this.chatService.deleteChat(id);
-  }
-
   @Patch('/:id')
   updateChat(
     @Param('id', ParseIntPipe) id,
     @Body() createChatDto: CreateChatDto,
+    @Req() req,
   ): Promise<Chat> {
-    return this.chatService.updateChat(id, createChatDto);
+    return this.chatService.updateChat(id, createChatDto, req.user.id);
   }
 
   @Get('participant/')

--- a/nestjs/src/chat/chat.service.ts
+++ b/nestjs/src/chat/chat.service.ts
@@ -102,11 +102,16 @@ export class ChatService {
     }
   }
 
-  async updateChat(id: number, createChatDto: CreateChatDto): Promise<Chat> {
+  async updateChat(
+    id: number,
+    createChatDto: CreateChatDto,
+    request_user_id: number,
+  ): Promise<Chat> {
     const chat = await this.getChatById(id);
     if (!chat) {
       throw new NotFoundException(`Can't find Chat id ${id}`);
     }
+    await this.checkAdminOrBoss(request_user_id, chat.id);
     this.checkChatStatusAndPassword(
       createChatDto.status,
       createChatDto.password,


### PR DESCRIPTION
## 관련 이슈
- #이슈번호
#130 
## 요약
채팅방 삭제 수정 API
<br><br>

## 작업내용
- 채팅방 삭제API는 없앴음(boss가 나갈때만 채팅방이 삭제되게 하기 위해서
- 채팅방 수정 API호출시 호출한 유저의 권한 boss or admin 확인
<br><br>

## 참고사항
<br><br>
