### PR TITLE
게임의 전반 적인 라이프사이클 도중 유저가 offline이 되었을 때 로직 처리

### DIFF
--- a/nestjs/src/socket/game/gameSocket.service.ts
+++ b/nestjs/src/socket/game/gameSocket.service.ts
@@ -233,6 +233,7 @@ export class GameSocketService {
       }
     }
     history.updateResult(winnerNickname, loserNickname);
+    curGame.setGameHistory(history);
     await this.gameHistoryRepository.createGameHistory({
       winnerId,
       loserId,

--- a/nestjs/src/socket/game/gameSocket.service.ts
+++ b/nestjs/src/socket/game/gameSocket.service.ts
@@ -15,6 +15,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { GameHistoryRepository } from './gameHistory.repository';
 import { GameStatus, TARGET_SCORE } from './enum/gameStatus.enum';
 import MatchHistory from './class/matchHistory';
+import { UserStatus } from './enum/userStatus.enum';
 
 @Injectable()
 export class GameSocketService {
@@ -163,23 +164,33 @@ export class GameSocketService {
       }
     }
 
-    // leftSidePlayer 득점
-    if (curBall.position.x + curBall.radius >= curRenderInfo.clientWidth) {
-      leftSidePlayer.score += 1;
-      curBall.initializePosition(
-        curRenderInfo.clientWidth / 2,
-        curRenderInfo.clientHeight / 2,
-      );
-      curBall.initializeVelocity();
-    }
-    // rightSidePlayer 득점
-    if (curBall.position.x - curBall.radius <= 0) {
-      rightSidePlayer.score += 1;
-      curBall.initializePosition(
-        curRenderInfo.clientWidth / 2,
-        curRenderInfo.clientHeight / 2,
-      );
-      curBall.initializeVelocity();
+    if (leftSidePlayer.status === UserStatus.ONLINE && rightSidePlayer.status === UserStatus.ONLINE) {
+      // leftSidePlayer 득점
+      if (curBall.position.x + curBall.radius >= curRenderInfo.clientWidth) {
+        leftSidePlayer.score += 1;
+        curBall.initializePosition(
+          curRenderInfo.clientWidth / 2,
+          curRenderInfo.clientHeight / 2,
+        );
+        curBall.initializeVelocity();
+      }
+      // rightSidePlayer 득점
+      if (curBall.position.x - curBall.radius <= 0) {
+        rightSidePlayer.score += 1;
+        curBall.initializePosition(
+          curRenderInfo.clientWidth / 2,
+          curRenderInfo.clientHeight / 2,
+        );
+        curBall.initializeVelocity();
+      }
+    } else {
+      if (leftSidePlayer.status === UserStatus.OFFLINE) {
+        leftSidePlayer.score = 0;
+        rightSidePlayer.score = TARGET_SCORE;
+      } else {
+        leftSidePlayer.score = TARGET_SCORE;
+        rightSidePlayer.score = 0;
+      }
     }
   }
 


### PR DESCRIPTION
## 관련 이슈
- close #102 

## 요약
게임 라이프 사이클 도중 유저 소켓이 끊겨 offline 상태가 되었을 때 로직 처리
<br><br>

## 작업내용
- 상세 구현 내용 이슈에 적어 놓았습니다.
<br><br>

## 참고사항
- 소켓이 끊겼을 때, 페이지 이동은 클라이언트에서 구현이 필요합니다.
- 뒤로가기 새로고침 버튼을 눌렀을 때 행동도 정해야 할 것 같습니다.
<br><br>
