### PR TITLE
Feat ban과 kick에 대한 소켓 이벤트 생성

### DIFF
--- a/nestjs/src/socket/home/connection.service.ts
+++ b/nestjs/src/socket/home/connection.service.ts
@@ -19,4 +19,8 @@ export class ConnectionService {
   removeUserConnection(userId: number): void {
     this.userConnections.delete(userId);
   }
+
+  findSocketByUserId(userId: number): Socket | undefined {
+    return this.userConnections[userId];
+  }
 }

--- a/nestjs/src/socket/home/dto/skill.dto.ts
+++ b/nestjs/src/socket/home/dto/skill.dto.ts
@@ -1,4 +1,4 @@
-export class MuteDto {
+export class SkillDto {
   roomId: string;
   target_user_id: string;
 }

--- a/nestjs/src/socket/home/dto/skill.dto.ts
+++ b/nestjs/src/socket/home/dto/skill.dto.ts
@@ -1,4 +1,4 @@
 export class SkillDto {
   roomId: string;
-  target_user_id: string;
+  targetUserId: string;
 }

--- a/nestjs/src/socket/home/home.gateway.ts
+++ b/nestjs/src/socket/home/home.gateway.ts
@@ -118,7 +118,7 @@ export class HomeGateway
       )
     ) {
       const targetSocket = this.connectionService.findSocketByUserId(
-        parseInt(skillDto.target_user_id),
+        parseInt(skillDto.targetUserId),
       );
       client.emit(
         'kickReturnStatus',

--- a/nestjs/src/socket/home/message.service.ts
+++ b/nestjs/src/socket/home/message.service.ts
@@ -55,51 +55,48 @@ export class MessageService {
   async muteUser(skillDto: SkillDto): Promise<string> {
     if (
       await this.chatParticipantRepository.getChatParticipantByUserChatRoom(
-        parseInt(skillDto.target_user_id),
+        parseInt(skillDto.targetUserId),
         parseInt(skillDto.roomId),
       )
     ) {
-      const muteUser = this.mute.get([
-        skillDto.target_user_id,
-        skillDto.roomId,
-      ]);
+      const muteUser = this.mute.get([skillDto.targetUserId, skillDto.roomId]);
       if (!muteUser) {
-        this.mute.set([skillDto.target_user_id, skillDto.roomId], true);
+        this.mute.set([skillDto.targetUserId, skillDto.roomId], true);
         setTimeout(() => {
-          this.mute.delete([skillDto.target_user_id, skillDto.roomId]);
+          this.mute.delete([skillDto.targetUserId, skillDto.roomId]);
         }, 10000); //10초동안 mute
-        return `user ${skillDto.target_user_id} is muted`;
+        return `user ${skillDto.targetUserId} is muted`;
       } else {
-        return `user ${skillDto.target_user_id} is already muted`;
+        return `user ${skillDto.targetUserId} is already muted`;
       }
     }
-    return `user ${skillDto.target_user_id} is not in chat room id ${skillDto.roomId}`;
+    return `user ${skillDto.targetUserId} is not in chat room id ${skillDto.roomId}`;
   }
 
   async kickUser(skillDto: SkillDto, targetSocket: Socket): Promise<string> {
     if (!targetSocket) {
-      return `user ${skillDto.target_user_id} is not in chat room id ${skillDto.roomId}`;
+      return `user ${skillDto.targetUserId} is not in chat room id ${skillDto.roomId}`;
     }
 
     const willKickedUser =
       await this.chatParticipantRepository.getChatParticipantByUserChatRoom(
-        parseInt(skillDto.target_user_id),
+        parseInt(skillDto.targetUserId),
         parseInt(skillDto.roomId),
       );
     if (willKickedUser.authority === ChatParticipantAuthority.BOSS) {
-      return `Can not kick boss ${skillDto.target_user_id}`;
+      return `Can not kick boss ${skillDto.targetUserId}`;
     }
     try {
       await this.chatParticipantRepository.deleteChatParticipant(
         parseInt(skillDto.roomId),
-        parseInt(skillDto.target_user_id),
+        parseInt(skillDto.targetUserId),
       );
     } catch {
-      return `user ${skillDto.target_user_id} is not in chat room id ${skillDto.roomId}`;
+      return `user ${skillDto.targetUserId} is not in chat room id ${skillDto.roomId}`;
     }
     targetSocket.leave(skillDto.roomId);
     targetSocket.emit(`kick`, 'You have been kicked from the room');
-    return `user ${skillDto.target_user_id} is kicked`;
+    return `user ${skillDto.targetUserId} is kicked`;
   }
 
   isImMute(user_id: string, chat_room_id: string): boolean {


### PR DESCRIPTION
## 관련 이슈
- #이슈번호
close #136 
## 요약
kick에 대해서만 소켓 이벤트 생성
<br><br>

## 작업내용
- kick을 요청한 사람의 권한 확인 boss or admin
- kick을 당하는 사람을 권한 확인 no boss
- kick을 당하는 사람은 room leave 후 kick 이벤트 받음
- kick을 요청한 사람은 kick성공 여부를 kickReturnStatus이벤트로 받음
<br><br>

## 참고사항
ban은 이 코드에서 처리 안하고 다른 이슈에서 해결할 예정
<br><br>
