### PR TITLE
Feat ban권한에 따른 기존 코드에서의 문제 발생

### DIFF
--- a/nestjs/src/chat/chat.controller.ts
+++ b/nestjs/src/chat/chat.controller.ts
@@ -50,11 +50,14 @@ export class ChatController {
   }
 
   @Get('participant/:chat_room_id')
-  getChatRoomByChatId(
+  getChatParticipantByChatId(
     @Param('chat_room_id', ParseIntPipe) chat_room_id,
     @Req() req,
   ): Promise<ChatParticipant[]> {
-    return this.chatService.getChatRoomByChatId(chat_room_id, req.user.id);
+    return this.chatService.getChatParticipantByChatId(
+      chat_room_id,
+      req.user.id,
+    );
   }
 
   @Post('participant/permission')

--- a/nestjs/src/chat/chatParticipant.repository.ts
+++ b/nestjs/src/chat/chatParticipant.repository.ts
@@ -48,6 +48,7 @@ export class ChatParticipantRepository extends Repository<ChatParticipant> {
     return this.createQueryBuilder('cp')
       .where('cp.user_id = :user_id', { user_id })
       .andWhere('cp.chat_room_id = :chat_room_id', { chat_room_id })
+      .andWhere('cp.ban IS NOT NULL')
       .getOne();
   }
 

--- a/nestjs/src/socket/home/connection.service.ts
+++ b/nestjs/src/socket/home/connection.service.ts
@@ -19,4 +19,8 @@ export class ConnectionService {
   removeUserConnection(userId: number): void {
     this.userConnections.delete(userId);
   }
+
+  findSocketByUserId(userId: number): Socket | undefined {
+    return this.userConnections[userId];
+  }
 }

--- a/nestjs/src/socket/home/dto/skill.dto.ts
+++ b/nestjs/src/socket/home/dto/skill.dto.ts
@@ -1,4 +1,4 @@
-export class MuteDto {
+export class SkillDto {
   roomId: string;
   target_user_id: string;
 }

--- a/nestjs/src/socket/home/dto/skill.dto.ts
+++ b/nestjs/src/socket/home/dto/skill.dto.ts
@@ -1,4 +1,4 @@
 export class SkillDto {
   roomId: string;
-  target_user_id: string;
+  targetUserId: string;
 }

--- a/nestjs/src/socket/home/home.gateway.ts
+++ b/nestjs/src/socket/home/home.gateway.ts
@@ -118,7 +118,7 @@ export class HomeGateway
       )
     ) {
       const targetSocket = this.connectionService.findSocketByUserId(
-        parseInt(skillDto.target_user_id),
+        parseInt(skillDto.targetUserId),
       );
       client.emit(
         'kickReturnStatus',

--- a/nestjs/src/socket/home/message.service.ts
+++ b/nestjs/src/socket/home/message.service.ts
@@ -55,51 +55,48 @@ export class MessageService {
   async muteUser(skillDto: SkillDto): Promise<string> {
     if (
       await this.chatParticipantRepository.getChatParticipantByUserChatRoom(
-        parseInt(skillDto.target_user_id),
+        parseInt(skillDto.targetUserId),
         parseInt(skillDto.roomId),
       )
     ) {
-      const muteUser = this.mute.get([
-        skillDto.target_user_id,
-        skillDto.roomId,
-      ]);
+      const muteUser = this.mute.get([skillDto.targetUserId, skillDto.roomId]);
       if (!muteUser) {
-        this.mute.set([skillDto.target_user_id, skillDto.roomId], true);
+        this.mute.set([skillDto.targetUserId, skillDto.roomId], true);
         setTimeout(() => {
-          this.mute.delete([skillDto.target_user_id, skillDto.roomId]);
+          this.mute.delete([skillDto.targetUserId, skillDto.roomId]);
         }, 10000); //10초동안 mute
-        return `user ${skillDto.target_user_id} is muted`;
+        return `user ${skillDto.targetUserId} is muted`;
       } else {
-        return `user ${skillDto.target_user_id} is already muted`;
+        return `user ${skillDto.targetUserId} is already muted`;
       }
     }
-    return `user ${skillDto.target_user_id} is not in chat room id ${skillDto.roomId}`;
+    return `user ${skillDto.targetUserId} is not in chat room id ${skillDto.roomId}`;
   }
 
   async kickUser(skillDto: SkillDto, targetSocket: Socket): Promise<string> {
     if (!targetSocket) {
-      return `user ${skillDto.target_user_id} is not in chat room id ${skillDto.roomId}`;
+      return `user ${skillDto.targetUserId} is not in chat room id ${skillDto.roomId}`;
     }
 
     const willKickedUser =
       await this.chatParticipantRepository.getChatParticipantByUserChatRoom(
-        parseInt(skillDto.target_user_id),
+        parseInt(skillDto.targetUserId),
         parseInt(skillDto.roomId),
       );
     if (willKickedUser.authority === ChatParticipantAuthority.BOSS) {
-      return `Can not kick boss ${skillDto.target_user_id}`;
+      return `Can not kick boss ${skillDto.targetUserId}`;
     }
     try {
       await this.chatParticipantRepository.deleteChatParticipant(
         parseInt(skillDto.roomId),
-        parseInt(skillDto.target_user_id),
+        parseInt(skillDto.targetUserId),
       );
     } catch {
-      return `user ${skillDto.target_user_id} is not in chat room id ${skillDto.roomId}`;
+      return `user ${skillDto.targetUserId} is not in chat room id ${skillDto.roomId}`;
     }
     targetSocket.leave(skillDto.roomId);
     targetSocket.emit(`kick`, 'You have been kicked from the room');
-    return `user ${skillDto.target_user_id} is kicked`;
+    return `user ${skillDto.targetUserId} is kicked`;
   }
 
   isImMute(user_id: string, chat_room_id: string): boolean {


### PR DESCRIPTION
## 관련 이슈
- #이슈번호
close #137 
## 요약
ban이 된 사용자에 대한 권한 확인 및 소켓 처리
<br><br>

## 작업내용
- 셀프 벤이 되는 현상 (boss가 boss밴 가능함)
- 채팅방 참여자를 가져오는 API가 ban인 사용자도 가져올 수 있는 현상
- ban이 된 사용자 권한을 제한해야 하는 API 검토
- ban이 되었을때 room에 join하고 있는 상태일 경우 소켓 이벤트 전송
<br><br>

## 참고사항
커밋이 꼬여서 두개로 나뉘어져 갔습니다
<br><br>
