### PR TITLE
게임 중 상대방 소켓이 끊겼을 때 이벤트 전송 순서에 따른 버그

### DIFF
--- a/nestjs/src/socket/game/enum/gameStatus.enum.ts
+++ b/nestjs/src/socket/game/enum/gameStatus.enum.ts
@@ -5,4 +5,5 @@ export enum GameStatus {
   IN_READY,
   IN_GAME,
   GAME_OVER,
+  GAME_OVER_IN_PLAYING,
 }

--- a/nestjs/src/socket/game/gameSocket.service.ts
+++ b/nestjs/src/socket/game/gameSocket.service.ts
@@ -150,7 +150,8 @@ export class GameSocketService {
     }
   }
 
-  updateScore(curRenderInfo: RenderInfo): void {
+  updateScore(curGame: Game): void {
+    const curRenderInfo = curGame.renderInfo;
     const curBall = curRenderInfo.ball;
     let leftSidePlayer: GamePlayer;
     let rightSidePlayer: GamePlayer;
@@ -164,7 +165,10 @@ export class GameSocketService {
       }
     }
 
-    if (leftSidePlayer.status === UserStatus.ONLINE && rightSidePlayer.status === UserStatus.ONLINE) {
+    if (
+      leftSidePlayer.status === UserStatus.ONLINE &&
+      rightSidePlayer.status === UserStatus.ONLINE
+    ) {
       // leftSidePlayer 득점
       if (curBall.position.x + curBall.radius >= curRenderInfo.clientWidth) {
         leftSidePlayer.score += 1;
@@ -184,6 +188,7 @@ export class GameSocketService {
         curBall.initializeVelocity();
       }
     } else {
+      curGame.updateStatus(GameStatus.GAME_OVER_IN_PLAYING);
       if (leftSidePlayer.status === UserStatus.OFFLINE) {
         leftSidePlayer.score = 0;
         rightSidePlayer.score = TARGET_SCORE;


### PR DESCRIPTION
## 관련 이슈
- close #147

## 요약
gameOverInPlaying 이벤트를 보내는 순서가 잘못 되어 생긴 버그 수정
<br><br>

## 작업내용
- game 상태에 gameOverInPlaying 상태를 추가
- 추가한 상태에 따라 이벤트가 전송될 수 있도록 수정

<br><br>

## 참고사항

<br><br>
