### PR TITLE
Feat 채팅방 차단 해제 api 생성

### DIFF
--- a/nestjs/src/chat/chat.respository.ts
+++ b/nestjs/src/chat/chat.respository.ts
@@ -1,4 +1,4 @@
-import { In, Repository } from 'typeorm';
+import { DeleteResult, In, Repository } from 'typeorm';
 import { Chat } from './entities/chat.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { CreateChatDto } from './dto/chatCreate.dto';
@@ -27,7 +27,7 @@ export class ChatRepository extends Repository<Chat> {
     return this.findOneBy({ id });
   }
 
-  deleteChat(id: number) {
+  deleteChat(id: number): Promise<DeleteResult> {
     return this.chatRepository.delete({ id });
   }
 

--- a/nestjs/src/chat/chatParticipant.repository.ts
+++ b/nestjs/src/chat/chatParticipant.repository.ts
@@ -1,10 +1,8 @@
-import { In, Not, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ChatParticipant } from './entities/chatParticipant.entity';
 import { ChatParticipantCreateDto } from './dto/chatParticipantCreate.dto';
-import { ChatRepository } from './chat.respository';
 import { NotFoundException } from '@nestjs/common';
-import { ChatStatus } from './enum/chat.status.enum';
 
 export class ChatParticipantRepository extends Repository<ChatParticipant> {
   constructor(

--- a/nestjs/src/socket/home/blackList.repository.ts
+++ b/nestjs/src/socket/home/blackList.repository.ts
@@ -1,0 +1,40 @@
+import { DeleteResult, Repository } from 'typeorm';
+import { BlackList } from './entities/blackList.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+
+export class BlackListRepository extends Repository<BlackList> {
+  constructor(
+    @InjectRepository(BlackList)
+    private blackListRepository: Repository<BlackList>,
+  ) {
+    super(
+      blackListRepository.target,
+      blackListRepository.manager,
+      blackListRepository.queryRunner,
+    );
+  }
+
+  getBlackListByFromId(fromUserId: number): Promise<BlackList[]> {
+    return this.find({ where: { from: { id: fromUserId } } });
+  }
+
+  async createBlackList(
+    fromUserId: number,
+    toUserId: number,
+  ): Promise<BlackList> {
+    const blackList = this.create({
+      from: { id: fromUserId },
+      to: { id: toUserId },
+    });
+    try {
+      await this.save(blackList);
+    } catch (error) {
+      console.log(error);
+    }
+    return blackList;
+  }
+
+  deleteBlackList(fromUserId: number, toUserId: number): Promise<DeleteResult> {
+    return this.delete({ from: { id: fromUserId }, to: { id: toUserId } });
+  }
+}

--- a/nestjs/src/socket/home/blackList.repository.ts
+++ b/nestjs/src/socket/home/blackList.repository.ts
@@ -26,12 +26,7 @@ export class BlackListRepository extends Repository<BlackList> {
       from: { id: fromUserId },
       to: { id: toUserId },
     });
-    try {
-      await this.save(blackList);
-    } catch (error) {
-      console.log(error);
-    }
-    return blackList;
+    return this.save(blackList);
   }
 
   deleteBlackList(fromUserId: number, toUserId: number): Promise<DeleteResult> {

--- a/nestjs/src/socket/home/dto/userId.dto.ts
+++ b/nestjs/src/socket/home/dto/userId.dto.ts
@@ -1,0 +1,3 @@
+export class UserIdDto {
+  userId: string;
+}

--- a/nestjs/src/socket/home/entities/blackList.entity.ts
+++ b/nestjs/src/socket/home/entities/blackList.entity.ts
@@ -1,0 +1,26 @@
+import { User } from 'src/auth/entities/User.entity';
+import {
+  BaseEntity,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+@Entity()
+export class BlackList extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'from_user_id' })
+  from: User;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'to_user_id' })
+  to: User;
+
+  @CreateDateColumn()
+  created_at: Date;
+}

--- a/nestjs/src/socket/home/home.gateway.ts
+++ b/nestjs/src/socket/home/home.gateway.ts
@@ -55,6 +55,7 @@ export class HomeGateway
         }, client['token_expiration'] - Date.now()); // timeOut 설정
         console.log(`home socket: ${client.id} connected`);
         client.emit('connection', '서버에 접속하였습니다');
+        this.messageService.initBlackList(jwt['id']);
       } else {
         client.emit('multipleConnect', '다중 로그인');
         client.disconnect(true);

--- a/nestjs/src/socket/home/home.gateway.ts
+++ b/nestjs/src/socket/home/home.gateway.ts
@@ -18,6 +18,7 @@ import { ConnectionService } from './connection.service';
 import { MessageService } from './message.service';
 import { SkillDto } from './dto/skill.dto';
 import { directMessageDto } from './dto/directMessage.dto';
+import { UserIdDto } from './dto/userId.dto';
 
 @WebSocketGateway({
   namespace: 'home',
@@ -102,6 +103,38 @@ export class HomeGateway
     } else {
       client.emit('directMessage', `${targetSocket['nickname']} is offline`);
     }
+  }
+
+  @SubscribeMessage('setBlackList')
+  async handleBlackList(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() payload: string,
+  ) {
+    const userIdDto: UserIdDto = JSON.parse(payload);
+
+    client.emit(
+      'setBlackList',
+      await this.messageService.setBlackList(
+        client['user_id'],
+        userIdDto.userId,
+      ),
+    );
+  }
+
+  @SubscribeMessage('unSetBlackList')
+  async handleUnSetBlackList(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() payload: string,
+  ) {
+    const userIdDto: UserIdDto = JSON.parse(payload);
+
+    client.emit(
+      'unSetBlackList',
+      await this.messageService.unSetBlackList(
+        client['user_id'],
+        userIdDto.userId,
+      ),
+    );
   }
 
   @SubscribeMessage('mute')

--- a/nestjs/src/socket/home/home.gateway.ts
+++ b/nestjs/src/socket/home/home.gateway.ts
@@ -78,9 +78,17 @@ export class HomeGateway
     if (this.messageService.isImMute(client['user_id'], messageDto.roomId)) {
       client.emit('message', 'Muted!!!!');
     } else {
-      client
-        .to(messageDto.roomId)
-        .emit('message', `${client['nickname']}: ${messageDto.inputMessage}`);
+      this.server.sockets.sockets.forEach(socket => {
+        if (
+          socket.rooms.has(messageDto.roomId) &&
+          !this.messageService.isBlackList(socket['user_id'], client['user_id'])
+        ) {
+          socket.emit(
+            'message',
+            `${client['nickname']}: ${messageDto.inputMessage}`,
+          );
+        }
+      });
     }
   }
 

--- a/nestjs/src/socket/home/home.gateway.ts
+++ b/nestjs/src/socket/home/home.gateway.ts
@@ -93,13 +93,19 @@ export class HomeGateway
     const targetSocket = this.connectionService.findSocketByUserId(
       parseInt(directMessageDto.targetUserId),
     );
-    //서로 block이 된 상태인지 확인하는 로직 필요
     if (targetSocket) {
-      this.handleLeaveAllRoom(client);
-      targetSocket.emit(
-        'directMessage',
-        `${client['nickname']}: ${directMessageDto.inputMessage}`,
-      );
+      if (
+        !this.messageService.isBlackList(
+          directMessageDto.targetUserId,
+          client['user_id'],
+        )
+      ) {
+        this.handleLeaveAllRoom(client);
+        targetSocket.emit(
+          'directMessage',
+          `${client['nickname']}: ${directMessageDto.inputMessage}`,
+        );
+      }
     } else {
       client.emit('directMessage', `${targetSocket['nickname']} is offline`);
     }

--- a/nestjs/src/socket/home/home.module.ts
+++ b/nestjs/src/socket/home/home.module.ts
@@ -8,15 +8,21 @@ import { MessageService } from './message.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Chat } from 'src/chat/entities/chat.entity';
 import { ChatParticipant } from 'src/chat/entities/chatParticipant.entity';
+import { BlackList } from './entities/blackList.entity';
+import { BlackListRepository } from './blackList.repository';
 
 @Module({
-  imports: [NormalJwtModule, TypeOrmModule.forFeature([Chat, ChatParticipant])],
+  imports: [
+    NormalJwtModule,
+    TypeOrmModule.forFeature([BlackList, Chat, ChatParticipant]),
+  ],
   providers: [
     HomeGateway,
     ConnectionService,
     MessageService,
     ChatParticipantRepository,
     ChatRepository,
+    BlackListRepository,
   ],
   exports: [ConnectionService, MessageService],
 })

--- a/nestjs/src/socket/home/message.service.ts
+++ b/nestjs/src/socket/home/message.service.ts
@@ -37,6 +37,39 @@ export class MessageService {
     });
   }
 
+  async setBlackList(fromUserId: string, toUserId: string): Promise<string> {
+    if (this.blackList.has([fromUserId, toUserId])) {
+      return 'already in black list';
+    }
+    await this.blackListRepository.createBlackList(
+      parseInt(fromUserId),
+      parseInt(toUserId),
+    );
+    this.blackList.set([fromUserId, toUserId], true);
+    return 'set black list success';
+  }
+
+  async unSetBlackList(fromUserId: string, toUserId: string): Promise<string> {
+    if (!this.blackList.has([fromUserId, toUserId])) {
+      return 'already not in black list';
+    }
+
+    const result = await this.blackListRepository.deleteBlackList(
+      parseInt(fromUserId),
+      parseInt(toUserId),
+    );
+    if (result.affected == 0) {
+      return 'delete error';
+    } else {
+      this.blackList.delete([fromUserId, toUserId]);
+    }
+    return 'unset black list success';
+  }
+
+  isBlackList(fromUserId: string, toUserId: string): boolean {
+    return this.blackList.has([fromUserId, toUserId]);
+  }
+
   getJwt(client: Socket) {
     let jwt = null;
     if (client.handshake.headers?.cookie) {

--- a/nestjs/src/socket/home/message.service.ts
+++ b/nestjs/src/socket/home/message.service.ts
@@ -8,19 +8,35 @@ import { parse } from 'cookie';
 import { NormalJwt } from 'src/jwt/interface/jwt.type';
 import { JwtService } from '@nestjs/jwt';
 import { SkillDto } from './dto/skill.dto';
+import { BlackListRepository } from './blackList.repository';
 
 @Injectable()
 export class MessageService {
   constructor(
     @Inject(NormalJwt)
     private readonly jwtService: JwtService,
+    @InjectRepository(BlackListRepository)
+    private blackListRepository: BlackListRepository,
     @InjectRepository(ChatRepository)
     private chatRepository: ChatRepository,
     @InjectRepository(ChatParticipantRepository)
     private chatParticipantRepository: ChatParticipantRepository,
   ) {}
-  //           Map<[user_id, chat_room_id], true/false>
+  //            Map<[user_id, chat_room_id], true/false>
   private mute: Map<[string, string], boolean> = new Map();
+  //            Map<[from_user_id, to_user_id], true/false>
+  private blackList: Map<[string, string], boolean> = new Map();
+
+  async initBlackList(fromUserId: number) {
+    const myBlackList = await this.blackListRepository.getBlackListByFromId(
+      fromUserId,
+    );
+    // myBlackList 배열을 사용하여 blackList 맵 채우기
+    myBlackList.forEach(item => {
+      this.blackList.set([fromUserId.toString(), item.to.id.toString()], true);
+    });
+  }
+
   getJwt(client: Socket) {
     let jwt = null;
     if (client.handshake.headers?.cookie) {


### PR DESCRIPTION
## 관련 이슈
- #이슈번호
#148 
## 요약
채팅방 차단 해제 api 생성
<br><br>

## 작업내용
- BlackList 테이블 생성
- black list 설정 / 해제 시에 DB와 메모리에 동시에 수정을 함
- socket connection시에 DB에 접근하여 메모리에 정보를 가져옴
- DM 또는 채팅방에서 메시지 전송시 발신유저를 black list로 올린 수신유저에게는 메시지 전송이 되지 않음
<br><br>

## 참고사항
- 앞으로 block / non block 이라는 용어 대신 set blackList / unset blacklist로 명명할 예정
- 발신 유저는 정상적으로 메시지를 보낼 수 있으므로 본인이 차단당한지 모름
- 과거 커밋부터 보시면 편하도록 해놨습니다
<br><br>
