### PR TITLE
Feat 157 aes 256 otp key에 적용

### DIFF
--- a/nestjs/src/auth/auth.module.ts
+++ b/nestjs/src/auth/auth.module.ts
@@ -9,6 +9,7 @@ import { UserRepository } from './user.repository';
 import { MulterModules } from 'src/multer/multer.module';
 import { NormalJwtModule } from 'src/jwt/jwt.module';
 import { HomeModule } from 'src/socket/home/home.module';
+import { CryptoService } from './utils/crypto.service';
 
 @Module({
   imports: [
@@ -20,6 +21,6 @@ import { HomeModule } from 'src/socket/home/home.module';
     HomeModule,
   ],
   controllers: [AuthController],
-  providers: [AuthService, UserRepository],
+  providers: [AuthService, UserRepository, CryptoService],
 })
 export class AuthModule {}

--- a/nestjs/src/auth/utils/crypto.service.ts
+++ b/nestjs/src/auth/utils/crypto.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+import * as crypto from 'crypto';
+
+@Injectable()
+export class CryptoService {
+  private readonly ENCRYPTION_KEY: string;
+  private readonly IV_LENGTH: number = 16;
+
+  constructor() {
+    if (!process.env.ENCRYPTION_KEY) {
+      throw new TypeError(
+        'ENCRYPTION_KEY 가 .env에 설정되어 있어야 합니다. .env파일을 update 해주세요.',
+      );
+    }
+    this.ENCRYPTION_KEY = process.env.ENCRYPTION_KEY;
+  }
+
+  encrypt(text: string): string {
+    const iv = crypto.randomBytes(this.IV_LENGTH);
+    const cipher = crypto.createCipheriv(
+      'aes-256-cbc',
+      Buffer.from(this.ENCRYPTION_KEY),
+      iv,
+    );
+    const encrypted = cipher.update(text);
+
+    return (
+      iv.toString('hex') +
+      ':' +
+      Buffer.concat([encrypted, cipher.final()]).toString('hex')
+    );
+  }
+
+  decrypt(text: string): string {
+    const textParts = text.split(':');
+    const iv = Buffer.from(textParts.shift(), 'hex');
+    const encryptedText = Buffer.from(textParts.join(':'), 'hex');
+    const decipher = crypto.createDecipheriv(
+      'aes-256-cbc',
+      Buffer.from(this.ENCRYPTION_KEY),
+      iv,
+    );
+    const decrypted = decipher.update(encryptedText);
+
+    return Buffer.concat([decrypted, decipher.final()]).toString();
+  }
+}

--- a/nestjs/src/profile/dto/otpSetup.dto.ts
+++ b/nestjs/src/profile/dto/otpSetup.dto.ts
@@ -1,9 +1,10 @@
-import { IsNotEmpty } from 'class-validator';
+import { IsNotEmpty, MinLength } from 'class-validator';
 
 export default class OtpSetupDto {
   @IsNotEmpty()
   token: string;
 
   @IsNotEmpty()
+  @MinLength(32)
   secret: string;
 }

--- a/nestjs/src/profile/profile.module.ts
+++ b/nestjs/src/profile/profile.module.ts
@@ -9,6 +9,7 @@ import { MulterModules } from 'src/multer/multer.module';
 import { NormalJwtModule } from 'src/jwt/jwt.module';
 import { FriendRequestingRepository } from 'src/friend/friendRequesting.repository';
 import { FriendRequesting } from 'src/friend/entities/FriendRequesting.entity';
+import { CryptoService } from 'src/auth/utils/crypto.service';
 
 @Module({
   imports: [
@@ -18,6 +19,11 @@ import { FriendRequesting } from 'src/friend/entities/FriendRequesting.entity';
     NormalJwtModule,
   ],
   controllers: [ProfileController],
-  providers: [ProfileService, UserRepository, FriendRequestingRepository],
+  providers: [
+    ProfileService,
+    UserRepository,
+    FriendRequestingRepository,
+    CryptoService,
+  ],
 })
 export class ProfileModule {}

--- a/nestjs/src/profile/profile.service.ts
+++ b/nestjs/src/profile/profile.service.ts
@@ -13,6 +13,7 @@ import { join } from 'path';
 import { User } from 'src/auth/entities/User.entity';
 import checkDuplicatedNicknameResponse from 'src/auth/interfaces/checkDuplicatedNicknameResponse.interface';
 import { UserRepository } from 'src/auth/user.repository';
+import { CryptoService } from 'src/auth/utils/crypto.service';
 import {
   FriendRequesting,
   RequestStatus,
@@ -33,6 +34,7 @@ export class ProfileService {
     private friendRequestingRepository: FriendRequestingRepository,
     @Inject(NormalJwt)
     private jwtService: JwtService,
+    private cryptoService: CryptoService,
   ) {}
 
   async myInfo(id: number): Promise<MyInfoDto> {
@@ -117,7 +119,7 @@ export class ProfileService {
     if (user.otp_key)
       throw new BadRequestException('이미 OTP KEY를 설정하셨습니다.');
 
-    user.otp_key = secret;
+    user.otp_key = this.cryptoService.encrypt(secret);
     try {
       await this.userRepository.save(user);
     } catch (error) {


### PR DESCRIPTION
## 관련 이슈
- #157

## 요약
- OTP_KEY를 DB에 바로 저장시키는 작업이 위험하다고 생각이 들어서, AES-256 방식으로 암호화 처리

<br><br>

## 작업내용
- cryptoService 생성
=> encrypt, decrypt 함수 생성
- otp 설정시 encrypt
- otp 검증시 decrypt

<br><br>

## 참고사항
- .env 파일 업데이트 하셔야 합니다

<br><br>
