### PR TITLE
generalgameservice 구현

### DIFF
--- a/nestjs/src/socket/home/generalGame.service.ts
+++ b/nestjs/src/socket/home/generalGame.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class GeneralGameService {
+  private generalGame: Map<number, number> = new Map();
+
+  findGeneralGame(fromUserId: number): boolean {
+    if (this.generalGame.has(fromUserId)) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  addGeneralGame(fromUserId: number, toUserId): boolean {
+    if (this.findGeneralGame(fromUserId)) {
+      return false;
+    } else {
+      this.generalGame.set(fromUserId, toUserId);
+      return true;
+    }
+  }
+
+  removeGeneralGame(fromUserId: number): void {
+    this.generalGame.delete(fromUserId);
+  }
+}

--- a/nestjs/src/socket/home/home.module.ts
+++ b/nestjs/src/socket/home/home.module.ts
@@ -10,6 +10,7 @@ import { Chat } from 'src/chat/entities/chat.entity';
 import { ChatParticipant } from 'src/chat/entities/chatParticipant.entity';
 import { BlackList } from './entities/blackList.entity';
 import { BlackListRepository } from './blackList.repository';
+import { GeneralGameService } from './generalGame.service';
 
 @Module({
   imports: [
@@ -23,7 +24,8 @@ import { BlackListRepository } from './blackList.repository';
     ChatParticipantRepository,
     ChatRepository,
     BlackListRepository,
+    GeneralGameService,
   ],
-  exports: [ConnectionService, MessageService],
+  exports: [ConnectionService, MessageService, GeneralGameService],
 })
 export class HomeModule {}


### PR DESCRIPTION
## 관련 이슈
- #187 

## 요약
일반 게임 매칭 로직 구현시 필요한 서비스 생성
<br><br>

## 작업내용
- home 소켓을 다루는 곳에서 일반 게임 초대 정보를 저장하기 위해 map 자료구조를 가지고 있는 GeneralGameService 생성
<br><br>

## 참고사항

<br><br>
