### PR TITLE
requestGeneralGame 이벤트 핸들러 구현

### DIFF
--- a/nestjs/src/socket/home/generalGame.service.ts
+++ b/nestjs/src/socket/home/generalGame.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class GeneralGameService {
+  private generalGame: Map<number, number> = new Map();
+
+  findGeneralGame(fromUserId: number): boolean {
+    if (this.generalGame.has(fromUserId)) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  addGeneralGame(fromUserId: number, toUserId): boolean {
+    if (this.findGeneralGame(fromUserId)) {
+      return false;
+    } else {
+      this.generalGame.set(fromUserId, toUserId);
+      return true;
+    }
+  }
+
+  removeGeneralGame(fromUserId: number): void {
+    this.generalGame.delete(fromUserId);
+  }
+}

--- a/nestjs/src/socket/home/home.module.ts
+++ b/nestjs/src/socket/home/home.module.ts
@@ -10,6 +10,7 @@ import { Chat } from 'src/chat/entities/chat.entity';
 import { ChatParticipant } from 'src/chat/entities/chatParticipant.entity';
 import { BlackList } from './entities/blackList.entity';
 import { BlackListRepository } from './blackList.repository';
+import { GeneralGameService } from './generalGame.service';
 
 @Module({
   imports: [
@@ -23,7 +24,8 @@ import { BlackListRepository } from './blackList.repository';
     ChatParticipantRepository,
     ChatRepository,
     BlackListRepository,
+    GeneralGameService,
   ],
-  exports: [ConnectionService, MessageService],
+  exports: [ConnectionService, MessageService, GeneralGameService],
 })
 export class HomeModule {}


### PR DESCRIPTION
## 관련 이슈
- #189 

## 요약
일반 게임 요청을 핸들링하는 subscriber 구현
<br><br>

## 작업내용
- 게임 요청 현황을 generalgameservice에 map으로 저장
- fromUser에게 waitingPlayer 이벤트 전송
- toUser에게 selectJoin 이벤트 전송
<br><br>

## 참고사항

<br><br>
