### PR TITLE
GeneralGameApprove 이벤트 핸들러 구현

### DIFF
--- a/nestjs/src/socket/game/gameConnection.service.ts
+++ b/nestjs/src/socket/game/gameConnection.service.ts
@@ -25,4 +25,10 @@ export class GameConnectionService {
   removeGameConnection(userId: number): void {
     this.gameConnections.delete(userId);
   }
+
+  getUserSocketInfoById(userId: number): Socket {
+    if (this.findGameConnection(userId)) {
+      return this.gameConnections.get(userId);
+    }
+  }
 }

--- a/nestjs/src/socket/game/gameSocket.module.ts
+++ b/nestjs/src/socket/game/gameSocket.module.ts
@@ -8,6 +8,7 @@ import { GameHistory } from './entities/gameHistory.entity';
 import { GameConnectionService } from './gameConnection.service';
 import { Ladder } from './entities/ladder.entity';
 import LadderRepository from './ladder.repository';
+import { GeneralGameService } from '../home/generalGame.service';
 
 @Module({
   imports: [NormalJwtModule, TypeOrmModule.forFeature([GameHistory, Ladder])],
@@ -17,6 +18,7 @@ import LadderRepository from './ladder.repository';
     GameHistoryRepository,
     LadderRepository,
     GameConnectionService,
+    GeneralGameService,
   ],
   exports: [GameConnectionService],
 })


### PR DESCRIPTION
## 관련 이슈
- #190 

## 요약
GeneralGameApprove 이벤트 핸들러 구현
<br><br>

## 작업내용
- toUser를 fromUser의 방으로 입장 시킨뒤에 게임 시작 로직을 시작한다(게임 옵션창 고르는 창으로 들어가기)
<br><br>

## 참고사항

<br><br>
