### PR TITLE
general game 검증 로직 및 예외처리 구현

### DIFF
--- a/nestjs/src/socket/game/gameSocket.gateway.ts
+++ b/nestjs/src/socket/game/gameSocket.gateway.ts
@@ -302,6 +302,19 @@ export class GameSocketGateway
     }
   }
 
+  @SubscribeMessage('validateSocketGeneral')
+  handleValidateGeneralGameSocket(@ConnectedSocket() client: Socket) {
+    if (
+      this.generalGameService.validateSocketGeneral(
+        this.users[client.id].userId,
+      )
+    ) {
+      client.emit('validateSuccessGeneral');
+    } else {
+      client.disconnect();
+    }
+  }
+
   @SubscribeMessage('generalGameApprove')
   handleGeneralGameApprove(
     @ConnectedSocket() client: Socket,

--- a/nestjs/src/socket/game/gameSocket.gateway.ts
+++ b/nestjs/src/socket/game/gameSocket.gateway.ts
@@ -339,20 +339,4 @@ export class GameSocketGateway
     this.generalGameService.removeGeneralGame(fromUserId);
     this.server.to(fromUserSocketId).emit('joinGame');
   }
-
-  @SubscribeMessage('generalGameRefuse')
-  handleGeneralGameRefuse(
-    @ConnectedSocket() client: Socket,
-    @MessageBody() data: number,
-  ) {
-    const fromUserId: number = data;
-    if (!this.generalGameService.findGeneralGame(fromUserId)) {
-      // 일반 게임 요청 거절 이벤트를 보내기 전 요청한 유저의 게임 소켓이 끊겼을 때 아무 행동도 하지 않는다
-      return;
-    }
-    const fromUserSocketId: string =
-      this.gameConnectionService.getUserSocketInfoById(fromUserId).id;
-    this.generalGameService.removeGeneralGame(fromUserId);
-    client.to(fromUserSocketId).emit('generalGameFail');
-  }
 }

--- a/nestjs/src/socket/game/gameSocket.gateway.ts
+++ b/nestjs/src/socket/game/gameSocket.gateway.ts
@@ -336,7 +336,6 @@ export class GameSocketGateway
     rightUser.updateRoomId(fromUserSocketId);
     this.games[fromUserSocketId].addUser(leftUser);
     this.games[fromUserSocketId].addUser(rightUser);
-    this.generalGameService.removeGeneralGame(fromUserId);
     this.server.to(fromUserSocketId).emit('joinGame');
   }
 }

--- a/nestjs/src/socket/home/generalGame.service.ts
+++ b/nestjs/src/socket/home/generalGame.service.ts
@@ -24,4 +24,13 @@ export class GeneralGameService {
   removeGeneralGame(fromUserId: number): void {
     this.generalGame.delete(fromUserId);
   }
+
+  validateSocketGeneral(userId: number): boolean {
+    for (const [key, value] of this.generalGame.entries()) {
+      if (key === userId || value === userId) {
+        return true;
+      }
+    }
+    return false;
+  }
 }


### PR DESCRIPTION
## 관련 이슈
- #191 

## 요약
general game 검증 로직 및 예외처리 구현
<br><br>

## 작업내용
- 기존의 generalGameRefuse로직은 게임 소켓을 잘 끊어주는 것으로 대체
- 예외 시나리오에 대한 로직 구현
    - A -> B 게임 요청
    - A가 요청하고 어떤 사유던 게임 소켓 끊김
    - B가 해당 요청을 수락함
    - B에게 상대방이 요청을 취소했다는 사실을 알림 
- /game/general url로 직접 접근하지 못하도록 검증 로직 구현
<br><br>

## 참고사항

<br><br>
