### PR TITLE
[Fix]: 벤이 된 사용자에 대한 오류처리

### DIFF
--- a/nestjs/src/chat/chat.service.ts
+++ b/nestjs/src/chat/chat.service.ts
@@ -288,14 +288,12 @@ export class ChatService {
       );
     }
     const chatParticipant =
-      await this.chatParticipantRepository.getChatParticipantByUserChatRoom(
+      await this.chatParticipantRepository.getAllChatParticipantByUserChatRoom(
         chatParticipantAuthorityDto.target_user_id,
         chatParticipantAuthorityDto.chat_room_id,
       );
-    if (!chatParticipant) {
-      throw new NotFoundException(
-        `Can't find ChatParticipant user_id ${chatParticipantAuthorityDto.target_user_id} chat_room_id ${chatParticipantAuthorityDto.chat_room_id}`,
-      );
+    if (!chatParticipant || chatParticipant.ban) {
+      throw new NotFoundException(`채팅방을 나갔거나 ban당한 유저입니다.`);
     } else if (
       chatParticipantAuthorityDto.authority === ChatParticipantAuthority.BOSS
     ) {
@@ -412,6 +410,16 @@ export class ChatService {
     if (requestParticipant.ban) {
       throw new UnauthorizedException(
         'You have been banned from this chat room',
+      );
+    }
+    const targetParticipant =
+      await this.chatParticipantRepository.getAllChatParticipantByUserChatRoom(
+        target_user_id,
+        chat_room_id,
+      );
+    if (!targetParticipant && targetParticipant.ban) {
+      throw new BadRequestException(
+        'ban이 된 사용자는 내보낼 수 없습니다. ban을 해제하고 다시 시도하세요',
       );
     }
     const result = await this.chatParticipantRepository.delete({

--- a/nestjs/src/socket/home/home.gateway.ts
+++ b/nestjs/src/socket/home/home.gateway.ts
@@ -183,7 +183,7 @@ export class HomeGateway
   }
 
   @SubscribeMessage('ban')
-  handleBanSomeone(
+  async handleBanSomeone(
     @ConnectedSocket() client: Socket,
     @MessageBody() payload: string,
   ) {
@@ -191,7 +191,12 @@ export class HomeGateway
     const targetSocket = this.connectionService.findSocketByUserId(
       skillDto.targetUserId,
     );
-    if (this.messageService.isBossOrAdmin(client['user_id'], skillDto.roomId)) {
+    if (
+      await this.messageService.isBossOrAdmin(
+        client['user_id'],
+        skillDto.roomId,
+      )
+    ) {
       if (targetSocket) {
         const rooms = targetSocket.rooms;
         if (rooms && rooms.has(skillDto.roomId.toString())) {


### PR DESCRIPTION

## 관련 이슈
- #이슈번호
#179 
## 요약
벤이 된 사용자에 대한 처리
<br><br>

## 작업내용
- kick, mute등 행동에서 이미 ban이 되었습니다 메시지 문구로 변경
- ban이 된 사용자는 kick을 당할 수 없게 함
- admin이 boss를 mute시키지 못하게 함

<br><br>

## 참고사항

<br><br>
