### PR TITLE
소켓으로 채팅방 상태 전송

### DIFF
--- a/nestjs/src/chat/chat.controller.ts
+++ b/nestjs/src/chat/chat.controller.ts
@@ -17,6 +17,7 @@ import { Chat } from './entities/chat.entity';
 import { ChatParticipant } from './entities/chatParticipant.entity';
 import { ChatJoinDto } from './dto/chatJoin.dto';
 import { ChatParticipantAuthorityDto } from './dto/chatParticipantAuthority.dto';
+import { ChatParticipantWithBlackList } from './interfaces/ChatParticipantWithBlackList.interface';
 
 @Controller('chat')
 @UseGuards(AuthGuard('jwt'))
@@ -53,7 +54,7 @@ export class ChatController {
   getAllParticipantByChatId(
     @Param('chat_room_id', ParseIntPipe) chat_room_id,
     @Req() req,
-  ): Promise<ChatParticipant[]> {
+  ): Promise<ChatParticipantWithBlackList[]> {
     return this.chatService.getAllParticipantByChatId(
       chat_room_id,
       req.user.id,

--- a/nestjs/src/chat/chat.module.ts
+++ b/nestjs/src/chat/chat.module.ts
@@ -8,14 +8,21 @@ import { ChatController } from './chat.controller';
 import { ChatRepository } from './chat.respository';
 import { ChatParticipantRepository } from './chatParticipant.repository';
 import { PassportsModule } from 'src/passports/passports.module';
+import { BlackList } from 'src/socket/home/entities/blackList.entity';
+import { BlackListRepository } from 'src/socket/home/blackList.repository';
 
 @Module({
   imports: [
     PassportsModule,
     NormalJwtModule,
-    TypeOrmModule.forFeature([Chat, ChatParticipant]),
+    TypeOrmModule.forFeature([Chat, ChatParticipant, BlackList]),
   ],
-  providers: [ChatService, ChatRepository, ChatParticipantRepository],
+  providers: [
+    ChatService,
+    ChatRepository,
+    ChatParticipantRepository,
+    BlackListRepository,
+  ],
   controllers: [ChatController],
 })
 export class ChatModule {}

--- a/nestjs/src/chat/chat.service.ts
+++ b/nestjs/src/chat/chat.service.ts
@@ -32,11 +32,13 @@ export class ChatService {
   checkChatStatusAndPassword(status: ChatStatus, password: string) {
     if (status === ChatStatus.PROTECTED || status === ChatStatus.PRIVATE) {
       if (!password || !password.trim()) {
-        throw new BadRequestException(`${status} room require password`);
+        throw new BadRequestException('비밀번호가 필요합니다');
       }
     } else {
       if (password && password.trim()) {
-        throw new BadRequestException(`${status} room do not require password`);
+        throw new BadRequestException(
+          '공개방은 비밀번호를 설정할 수 없습니다.',
+        );
       }
     }
   }
@@ -46,9 +48,7 @@ export class ChatService {
     chat_room_id: number,
   ): Promise<ChatParticipant> {
     if (!(await this.chatRepository.getChatByChatId(chat_room_id))) {
-      throw new UnauthorizedException(
-        `chat_room_id ${chat_room_id} does not exist`,
-      );
+      throw new UnauthorizedException('채팅방을 찾을 수 없습니다');
     }
     const participant =
       await this.chatParticipantRepository.getChatParticipantByUserChatRoom(
@@ -56,14 +56,10 @@ export class ChatService {
         chat_room_id,
       );
     if (!participant) {
-      throw new UnauthorizedException(
-        `user_id ${user_id} is not in chat_room_id ${chat_room_id}`,
-      );
+      throw new UnauthorizedException('유저를 찾을 수 없습니다.');
     }
     if (participant.authority === ChatParticipantAuthority.NORMAL) {
-      throw new UnauthorizedException(
-        `user_id ${user_id} is not boss or admin`,
-      );
+      throw new UnauthorizedException('권한이 없습니다.');
     }
     return participant;
   }
@@ -102,7 +98,7 @@ export class ChatService {
     const result = await this.chatRepository.deleteChat(id);
 
     if (result.affected === 0) {
-      throw new NotFoundException(`Can't find Chat with id ${id}`);
+      throw new NotFoundException('채팅방을 찾을 수 없습니다.');
     }
   }
 
@@ -113,13 +109,11 @@ export class ChatService {
   ): Promise<Chat> {
     const chat = await this.getChatById(id);
     if (!chat) {
-      throw new NotFoundException(`Can't find Chat id ${id}`);
+      throw new NotFoundException('채팅방을 찾을 수 없습니다.');
     }
     const participant = await this.checkAdminOrBoss(request_user_id, chat.id);
     if (participant.ban !== null) {
-      throw new UnauthorizedException(
-        'You have been banned from this chat room',
-      );
+      throw new UnauthorizedException('이 채팅방에서 추방당했습니다.');
     }
     this.checkChatStatusAndPassword(
       createChatDto.status,
@@ -154,13 +148,9 @@ export class ChatService {
         chat_room_id,
       );
     if (!chatParticipant) {
-      throw new UnauthorizedException(
-        'You do not have permission for this chat room',
-      );
+      throw new UnauthorizedException('채팅방에 참여할 권한이 없습니다.');
     } else if (chatParticipant.ban) {
-      throw new UnauthorizedException(
-        'You have been banned from this chat room',
-      );
+      throw new UnauthorizedException('이 채팅방에서 추방당했습니다.');
     }
     const blackList = await this.blackListRepository.getBlackListByFromId(
       user_id,
@@ -175,7 +165,6 @@ export class ChatService {
       );
       return { ...participant, blackList: isBlacklisted };
     });
-    console.log(participantsWithBlackList);
     return participantsWithBlackList;
   }
 
@@ -189,13 +178,9 @@ export class ChatService {
         chat_room_id,
       );
     if (!chatParticipant) {
-      throw new UnauthorizedException(
-        'You do not have permission for this chat room',
-      );
+      throw new UnauthorizedException('채팅방에 참여할 권한이 없습니다.');
     } else if (chatParticipant.ban) {
-      throw new UnauthorizedException(
-        'You have been banned from this chat room',
-      );
+      throw new UnauthorizedException('이 채팅방에서 추방당했습니다.');
     }
     return chatParticipant;
   }
@@ -210,19 +195,15 @@ export class ChatService {
       chatJoinDto.chat_room_id,
     );
     if (!chatParticipant) {
-      throw new UnauthorizedException(
-        'You do not have permission for this chat room',
-      );
+      throw new UnauthorizedException('채팅방에 참여할 권한이 없습니다.');
     } else if (chatParticipant.ban !== null) {
-      throw new UnauthorizedException(
-        'You have been banned from this chat room',
-      );
+      throw new UnauthorizedException('이 채팅방에서 추방당했습니다.');
     } else if (
       chatRoom.status === ChatStatus.PROTECTED &&
       (!chatJoinDto.password ||
         !(await bcrypt.compare(chatJoinDto.password, chatRoom.password)))
     ) {
-      throw new UnauthorizedException('password does not match');
+      throw new UnauthorizedException('잘못된 비밀번호입니다.');
     }
     return chatParticipant;
   }
@@ -243,7 +224,7 @@ export class ChatService {
       );
     } else if (chatRoom.status === ChatStatus.PROTECTED) {
       if (!(await bcrypt.compare(chatJoinDto.password, chatRoom.password))) {
-        throw new UnauthorizedException('password does not match');
+        throw new UnauthorizedException('잘못된 비밀번호입니다.');
       } else {
         const chatParticipantCreateDto = {
           chat_room_id: chatJoinDto.chat_room_id,
@@ -265,12 +246,10 @@ export class ChatService {
       chatJoinDto.chat_room_id,
     );
     if (!chat) {
-      throw new BadRequestException(
-        `Chat room id ${chatJoinDto.chat_room_id} does not exist`,
-      );
+      throw new BadRequestException('채팅방을 찾을 수 없습니다.');
     }
     if (chat.status === ChatStatus.PRIVATE) {
-      throw new BadRequestException('Can not join private room');
+      throw new BadRequestException('비공개방에는 참여할 수 없습니다.');
     }
     const participant =
       await this.chatParticipantRepository.getAllChatParticipantByUserChatRoom(
@@ -279,13 +258,9 @@ export class ChatService {
       );
     if (participant) {
       if (participant.ban) {
-        throw new BadRequestException(
-          `You have been banned from this chat room`,
-        );
+        throw new BadRequestException('이 채팅방에서 추방당했습니다.');
       } else {
-        throw new BadRequestException(
-          `User ${user_id} already in ${chatJoinDto.chat_room_id}`,
-        );
+        throw new BadRequestException('이미 참여중입니다');
       }
     }
     return this.creatNewChat(chatJoinDto, user_id, chat);
@@ -300,9 +275,7 @@ export class ChatService {
       chatParticipantAuthorityDto.chat_room_id,
     );
     if (requestParticipant.ban) {
-      throw new UnauthorizedException(
-        'You have been banned from this chat room',
-      );
+      throw new UnauthorizedException('이 채팅방에서 추방당했습니다.');
     }
     const chatParticipant =
       await this.chatParticipantRepository.getAllChatParticipantByUserChatRoom(
@@ -310,13 +283,13 @@ export class ChatService {
         chatParticipantAuthorityDto.chat_room_id,
       );
     if (!chatParticipant || chatParticipant.ban) {
-      throw new NotFoundException(`채팅방을 나갔거나 ban당한 유저입니다.`);
+      throw new NotFoundException(`채팅방을 나갔거나 추방당한 유저입니다.`);
     } else if (
       chatParticipantAuthorityDto.authority === ChatParticipantAuthority.BOSS
     ) {
-      throw new UnauthorizedException(`Can't switch authority to boss`);
+      throw new UnauthorizedException('방장으로 권한을 바꿀 수 없습니다.');
     } else if (chatParticipant.authority === ChatParticipantAuthority.BOSS) {
-      throw new UnauthorizedException(`Can't switch boss's authority`);
+      throw new UnauthorizedException('방장의 권한은 바꿀 수 없습니다.');
     }
     chatParticipant.authority = chatParticipantAuthorityDto.authority;
     return this.chatParticipantRepository.save(chatParticipant);
@@ -332,12 +305,10 @@ export class ChatService {
       chat_room_id,
     );
     if (requestParticipant.ban) {
-      throw new UnauthorizedException(
-        'You have been banned from this chat room',
-      );
+      throw new UnauthorizedException('이 채팅방에서 추방당했습니다.');
     }
     if (request_user_id === target_user_id) {
-      throw new UnauthorizedException('Can not ban yourself');
+      throw new UnauthorizedException('스스로 추방할 수 없습니다');
     }
     const chatParticipant =
       await this.chatParticipantRepository.getChatParticipantByUserChatRoom(
@@ -345,13 +316,11 @@ export class ChatService {
         chat_room_id,
       );
     if (!chatParticipant) {
-      throw new NotFoundException(
-        `Can't find ChatParticipant user_id ${target_user_id} chat_room_id ${chat_room_id}`,
-      );
+      throw new NotFoundException('유저를 찾을 수 없습니다.');
     } else if (chatParticipant.authority === ChatParticipantAuthority.BOSS) {
-      throw new BadRequestException('Can not ban boss');
+      throw new BadRequestException('방장은 추방할 수 없습니다.');
     } else if (chatParticipant.ban) {
-      throw new NotFoundException(`Already banned`);
+      throw new NotFoundException('이미 추방했습니다');
     }
     chatParticipant.ban = new Date();
     return this.chatParticipantRepository.save(chatParticipant);
@@ -367,12 +336,10 @@ export class ChatService {
       chat_room_id,
     );
     if (requestParticipant.ban) {
-      throw new UnauthorizedException(
-        'You have been banned from this chat room',
-      );
+      throw new UnauthorizedException('이 채팅방에서 추방당했습니다.');
     }
     if (request_user_id === target_user_id) {
-      throw new UnauthorizedException('Can not unban yourself');
+      throw new UnauthorizedException('스스로 추방을 해제할 수 없습니다');
     }
     const chatParticipant =
       await this.chatParticipantRepository.getAllChatParticipantByUserChatRoom(
@@ -380,12 +347,10 @@ export class ChatService {
         chat_room_id,
       );
     if (!chatParticipant) {
-      throw new NotFoundException(
-        `Can't find ChatParticipant user_id ${target_user_id} chat_room_id ${chat_room_id}`,
-      );
+      throw new NotFoundException('유저를 찾을 수 없습니다.');
     }
     if (!chatParticipant.ban) {
-      throw new NotFoundException(`Already not banned`);
+      throw new NotFoundException('이미 추방이 해제되어있습니다');
     }
     chatParticipant.ban = null;
     return this.chatParticipantRepository.save(chatParticipant);
@@ -401,9 +366,7 @@ export class ChatService {
         chat_room_id,
       );
     if (!chatParticipant) {
-      throw new NotFoundException(
-        `Can't find ChatParticipant user_id ${user_id} chat_room_id ${chat_room_id}`,
-      );
+      throw new NotFoundException('유저를 찾을 수 없습니다.');
     }
     if (chatParticipant.authority === ChatParticipantAuthority.BOSS) {
       await this.deleteChat(chat_room_id);
@@ -425,9 +388,7 @@ export class ChatService {
       chat_room_id,
     );
     if (requestParticipant.ban) {
-      throw new UnauthorizedException(
-        'You have been banned from this chat room',
-      );
+      throw new UnauthorizedException('이 채팅방에서 추방당했습니다.');
     }
     const targetParticipant =
       await this.chatParticipantRepository.getAllChatParticipantByUserChatRoom(
@@ -436,7 +397,7 @@ export class ChatService {
       );
     if (!targetParticipant && targetParticipant.ban) {
       throw new BadRequestException(
-        'ban이 된 사용자는 내보낼 수 없습니다. ban을 해제하고 다시 시도하세요',
+        '추방된 사용자는 내보낼 수 없습니다. 추방을 해제하고 다시 시도하세요',
       );
     }
     const result = await this.chatParticipantRepository.delete({
@@ -445,9 +406,7 @@ export class ChatService {
     });
 
     if (result.affected === 0) {
-      throw new NotFoundException(
-        `Can't find Chat with user_id ${target_user_id} chat_room_id ${chat_room_id}`,
-      );
+      throw new NotFoundException('유저를 찾을 수 없습니다.');
     }
   }
 }

--- a/nestjs/src/chat/interfaces/ChatParticipantWithBlackList.interface.ts
+++ b/nestjs/src/chat/interfaces/ChatParticipantWithBlackList.interface.ts
@@ -1,0 +1,13 @@
+import { User } from 'src/auth/entities/User.entity';
+import { Chat } from '../entities/chat.entity';
+import { ChatParticipantAuthority } from '../enum/chatParticipant.authority.enum';
+
+export interface ChatParticipantWithBlackList {
+  blackList: boolean;
+  id: number;
+  chat: Chat;
+  user: User;
+  authority: ChatParticipantAuthority;
+  ban: Date;
+  authority_time: Date;
+}

--- a/nestjs/src/socket/home/home.gateway.ts
+++ b/nestjs/src/socket/home/home.gateway.ts
@@ -205,14 +205,12 @@ export class HomeGateway
             'ban',
             `You have been left from the room: ${skillDto.roomId}`,
           );
-          client.emit(
-            'banReturnStatus',
-            'Successfully banned the user and left them from the room',
-          );
         }
-      } else {
-        client.emit('banReturnStatus', 'Target User is not connected');
       }
+      client.emit(
+        'banReturnStatus',
+        'Successfully banned the user and left them from the room',
+      );
     } else {
       client.emit('banReturnStatus', 'You do not have the right to ban others');
     }
@@ -224,9 +222,6 @@ export class HomeGateway
     @MessageBody() payload: string,
   ) {
     const skillDto: SkillDto = JSON.parse(payload);
-    const targetSocket = this.connectionService.findSocketByUserId(
-      skillDto.targetUserId,
-    );
     client.emit(
       'unbanReturnStatus',
       'Successfully unbaned the user and left them from the room',

--- a/nestjs/src/socket/home/home.gateway.ts
+++ b/nestjs/src/socket/home/home.gateway.ts
@@ -222,6 +222,14 @@ export class HomeGateway
     @MessageBody() payload: string,
   ) {
     const skillDto: SkillDto = JSON.parse(payload);
+    const targetSocket = this.connectionService.findSocketByUserId(
+      skillDto.targetUserId,
+    );
+
+    // if (targetSocket) {
+    //   targetSocket.emit('ban', `${skillDto.roomId} 채팅방에서 ban이 해제되었습니다.`);
+    // }
+    // 여기서 `${채팅방 이름}에서 ban이 해제되었습니다.` 이런 메시지를 보내줄 수 있었으면 좋겠는데 채팅방 이름을 받아올 방법이...ㅜ
     client.emit(
       'unbanReturnStatus',
       'Successfully unbaned the user and left them from the room',

--- a/nestjs/src/socket/home/home.gateway.ts
+++ b/nestjs/src/socket/home/home.gateway.ts
@@ -218,6 +218,21 @@ export class HomeGateway
     }
   }
 
+  @SubscribeMessage('unban')
+  async handleUnBanSomeone(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() payload: string,
+  ) {
+    const skillDto: SkillDto = JSON.parse(payload);
+    const targetSocket = this.connectionService.findSocketByUserId(
+      skillDto.targetUserId,
+    );
+    client.emit(
+      'unbanReturnStatus',
+      'Successfully unbaned the user and left them from the room',
+    );
+  }
+
   @SubscribeMessage('kick')
   async handleKickSomeone(
     @ConnectedSocket() client: Socket,


### PR DESCRIPTION
## 관련 이슈
- #이슈번호
#197 
## 요약
소켓을 이용해 채팅방 상태를 전송해야 하는 로직을 수정했습니다.
<br><br>

## 작업내용
- unban 소켓 이벤트 추가하여 프론트에서 unban에 대한 메시지를 띄울 수 있게 하였습니다.
- 소켓이 연결되지 않을 때 ban이 되지 않는 문제를 해결했습니다.
- 채팅방 참여자 목록 반환 API에 blackList 속성을 boolean값으로 추가했습니다. 이로써 프론트에서 blackList 관리를 더 수월하게 할 수 있도록 했습니다.
- 참여자 권한이 바뀔때 요청자와, 바뀐 타깃 유저에게 소켓 메시지를 보냅니다
- 에러 메시지와 소켓으로 통신하는 메시지를 한글로 바꿨습니다.
<br><br>

## 참고사항
- Question 커밋이 봐주세요!
<br><br>
