### PR TITLE
[Hotfix]: 채팅 참여하고 있는 모든 참여자에게 소켓 이벤트를 보내주도록 수정

### DIFF
--- a/nestjs/src/socket/home/home.gateway.ts
+++ b/nestjs/src/socket/home/home.gateway.ts
@@ -246,6 +246,7 @@ export class HomeGateway
       );
     }
     client.emit('toAdminReturnStatus', '관리자 권한 부여 성공');
+    client.to(skillDto.roomId.toString()).emit('toAdmin');
   }
 
   @SubscribeMessage('toNormal')
@@ -260,11 +261,12 @@ export class HomeGateway
 
     if (targetSocket) {
       targetSocket.emit(
-        'toAdmin',
+        'toNormal',
         `${targetSocket['nickname']}님에게 관리자 자격이 해제되었습니다.`,
       );
     }
     client.emit('toNormalReturnStatus', '관리자 권한 취소 성공');
+    client.to(skillDto.roomId.toString()).emit('toNormal');
   }
 
   @SubscribeMessage('kick')


### PR DESCRIPTION
## 관련 이슈
- #이슈번호
#219 
## 요약
관리자권한 변경시 소켓이벤트
<br><br>

## 작업내용
- targetSocket과 request socket에게만 보내주던 것을 room에 참여한 모든 참여자에게 보냄
<br><br>

## 참고사항

<br><br>
