### PR TITLE
[Fix]: private채팅방 입장시 비밀번호 검증 로직 수정

### DIFF
--- a/nestjs/src/chat/chat.service.ts
+++ b/nestjs/src/chat/chat.service.ts
@@ -208,7 +208,8 @@ export class ChatService {
     } else if (chatParticipant.ban !== null) {
       throw new UnauthorizedException('이 채팅방에서 추방당했습니다.');
     } else if (
-      chatRoom?.status === ChatStatus.PROTECTED &&
+      (chatRoom?.status === ChatStatus.PROTECTED ||
+        chatRoom?.status === ChatStatus.PRIVATE) &&
       (!chatJoinDto.password ||
         !(await bcrypt.compare(chatJoinDto.password, chatRoom.password)))
     ) {


### PR DESCRIPTION
## 요약
private 채팅방 입장시 비밀번호를 검증 안하고 있는 버그 수정
<br><br>

## 작업내용

<br><br>

## 참고사항

<br><br>
