### PR TITLE
pingpong 게임 타겟 스코어 변경

### DIFF
--- a/nestjs/src/socket/game/enum/gameStatus.enum.ts
+++ b/nestjs/src/socket/game/enum/gameStatus.enum.ts
@@ -1,4 +1,4 @@
-export const TARGET_SCORE = 3;
+export const TARGET_SCORE = 10;
 export const LADDER_WIN_DELTA_SCORE = 100;
 export const LADDER_LOSE_DELTA_SCORE = -50;
 export enum GameStatus {

--- a/nestjs/src/socket/game/gameSocket.service.ts
+++ b/nestjs/src/socket/game/gameSocket.service.ts
@@ -154,8 +154,8 @@ export class GameSocketService {
         dx <= gamePlayerBar.width / 2 + curBall.radius &&
         dy <= gamePlayerBar.length / 2 + curBall.radius
       ) {
-        curBall.velocity.x *= -1.2;
-        curBall.velocity.y *= 1.2;
+        curBall.velocity.x *= -1.1;
+        curBall.velocity.y *= 1.1;
       }
     }
   }


### PR DESCRIPTION
## 관련 이슈
- #234 

## 요약
- pingpong 게임 타겟 스코어
<br><br>

## 작업내용
- 게임 종료 점수 10점으로 변경
- 바 충돌 시 공 속도 변경 수치 변경
<br><br>

## 참고사항

<br><br>
