### PR TITLE
otp 설정해제 시 해제 안되는 버그

### DIFF
--- a/nestjs/src/profile/profile.service.ts
+++ b/nestjs/src/profile/profile.service.ts
@@ -197,7 +197,7 @@ export class ProfileService {
   async deleteOtp(id: number): Promise<void> {
     const user: User | null = await this.userRepository.findOneBy({ id });
     if (!user || !user.otp_key) return;
-    user.otp_key = undefined;
+    user.otp_key = null;
     try {
       await this.userRepository.save(user);
     } catch (error) {


### PR DESCRIPTION
## 관련 이슈
- #237 

## 요약
otp 설정해제 시 해제 안되는 버그
<br><br>

## 작업내용
- 엔티티에 null로 저장하는 것으로 변경
<br><br>

## 참고사항

<br><br>
